### PR TITLE
pkg_pretend sample used deprecated error message format

### DIFF
--- a/ebuild-writing/functions/pkg_pretend/text.xml
+++ b/ebuild-writing/functions/pkg_pretend/text.xml
@@ -53,7 +53,7 @@ pkg_pretend() {
 		if [[ -e "${ROOT}"/usr/src/linux/.config ]] ; then
 			if kernel_is lt 2 6 30 ; then
 				CONFIG_CHECK="FUSE_FS"
-				FUSE_FS_ERROR="this is an unrealistic testcase..."
+				ERROR_FUSE_FS="this is an unrealistic testcase..."
 				check_extra_config
 			fi
 		fi


### PR DESCRIPTION
Since linux-info.eclass's revision 1.35, which fixed bug #113142, ERROR_\* is the preferred format for error message variable names.

This pull request will fix https://bugs.gentoo.org/show_bug.cgi?id=478062
