### PR TITLE
Explicit link titles for <uri /> tags linking to the eclass reference

### DIFF
--- a/appendices/contributors/text.xml
+++ b/appendices/contributors/text.xml
@@ -17,7 +17,7 @@ This page lists the contributions to the Gentoo Development Guide:
 </author>
 <author name="Aaron Walker" email="ka0ttic@gentoo.org">
   <uri link="::tasks-reference/completion"/>,
-  <uri link="::eclass-reference/subversion.eclass"/>
+  <uri link="::eclass-reference/subversion.eclass">subversion.eclass</uri>
 </author>
 <author name="Robert Coie" email="rac@gentoo.org">
   <uri link="::appendices/editor-configuration/xemacs"/>

--- a/ebuild-writing/functions/src_compile/build-environment/text.xml
+++ b/ebuild-writing/functions/src_compile/build-environment/text.xml
@@ -141,7 +141,7 @@ functions can be used here.
 </codesample>
 
 <p>
-See <uri link="::eclass-reference/flag-o-matic.eclass/"/> for a full reference.
+See <uri link="::eclass-reference/flag-o-matic.eclass/">flag-o-matic.eclass</uri> for a full reference.
 </p>
 </body>
 </section>

--- a/ebuild-writing/functions/src_unpack/svn-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/svn-sources/text.xml
@@ -6,7 +6,7 @@
 <body>
 <p>
 As with CVS, an eclass exists for working directly with upstream
-Subversion repositories. See <uri link="eclass-reference/subversion.eclass/"/>
+Subversion repositories. See <uri link="::eclass-reference/subversion.eclass/">subversion.eclass</uri>
 for a full list of functions and variables. Also see
 the <uri link="::ebuild-writing/functions/src_unpack/cvs-sources"/> 
 ection.
@@ -82,7 +82,7 @@ following variables are also noteworthy:
 </table>
 
 <p>
-See the eclass itself and <uri link="eclass-reference/subversion.eclass/"/>
+See the eclass itself and <uri link="::eclass-reference/subversion.eclass/">subversion.eclass</uri>
 for the full range of options. To perform the actual checkout, use
 the <c>subversion_src_unpack</c> function, which calls
 both <c>subversion_svn_fetch</c> and <c>subversion_bootstrap</c>

--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -7,7 +7,7 @@
 <p>
 An eclass is a collection (library) of functions or functionality that is shared
 between packages. See <uri link="::eclass-writing/" /> for the full story on what
-eclasses can do, how they work and how to write them, and <uri link="::eclass-reference/"/>
+eclasses can do, how they work and how to write them, and <uri link="::eclass-reference/">the eclass reference</uri>
 for documentation on various commonly used eclasses. This section only explains
 how to use an eclass which has already been written.
 </p>
@@ -77,10 +77,10 @@ Note the <c>inherit</c> immediately after the header.
 </p>
 
 <p>
-The <c>eutils</c> eclass (see <uri link="::eclass-reference/eutils.eclass/"/>) is needed to get the
+The <c>eutils</c> eclass (see <uri link="::eclass-reference/eutils.eclass/">eutils.eclass</uri>) is needed to get the
 <c>epatch</c> function.  The <c>flag-o-matic</c> eclass (see <uri
-link="::eclass-reference/flag-o-matic.eclass/"/>) is needed for <c>replace-flags</c>, and
-the <c>bash-completion</c> eclass (<uri link="::eclass-reference/bash-completion.eclass/"/>) is used
+link="::eclass-reference/flag-o-matic.eclass/">flag-o-matic.eclass</uri>) is needed for <c>replace-flags</c>, and
+the <c>bash-completion</c> eclass (<uri link="::eclass-reference/bash-completion.eclass/">bash-completion.eclass</uri>) is used
 to handle the bash completion file via <c>dobashcompletion</c> and <c>bash-completion_pkg_postinst</c>.
 </p>
 

--- a/tasks-reference/completion/text.xml
+++ b/tasks-reference/completion/text.xml
@@ -7,7 +7,7 @@
 <p>
 Since v2.05a, <c>bash</c> has offered intelligent programmable completion.  Writing
 such completions for your own programs/things you maintain is relatively easy
-provided you know bash already. See <uri link="::eclass-reference/bash-completion.eclass/"/>
+provided you know bash already. See <uri link="::eclass-reference/bash-completion.eclass/">bash-completion.eclass</uri>
 for how to install completion files.
 </p>
 


### PR DESCRIPTION
Fix for https://bugs.gentoo.org/show_bug.cgi?id=475332

(messed up the previous pull request, sorry)
