### PR TITLE
Add a reference to the Gentoo Developer Handbook.

### DIFF
--- a/text.xml
+++ b/text.xml
@@ -30,6 +30,7 @@ and file a <uri link="https://bugs.gentoo.org/enter_bug.cgi?product=Doc%20Other;
 The <uri link="::appendices/contributors"/>
 section lists specific contributions to this manual.
 </p>
+<p>Users that are interested in becoming a Gentoo Developer are encouraged to also read the <uri link="http://www.gentoo.org/proj/en/devrel/handbook/handbook.xml">Gentoo Developer Handbook</uri>.</p>
 </body>
 
 <section>


### PR DESCRIPTION
Idea that came up in the "[gentoo-project] Re: Daunting developer process?" ML thread, not sure if the wording or place or link is fine; we could possible discuss better alternatives in this pull request. I think interlinking our documents could help our users to find such relevant documentation easily, which they might otherwise be unaware of.
