### PR TITLE
ebuild-writing/functions: Don't allow network access

### DIFF
--- a/ebuild-writing/functions/text.xml
+++ b/ebuild-writing/functions/text.xml
@@ -35,6 +35,19 @@ When testing or debugging, you can instruct Portage to execute a specific functi
 from an ebuild by using the <c>ebuild</c> command, see the <c>ebuild(1)</c> manual
 page for further information.
 </p>
+
+<p>
+Downloading a package's source happens before any of these phases, so
+<c>emerge --fetchonly</c> should perform all the network access you
+need (unless you're using live ebuilds).  Network access outside of
+this would not be cached locally (e.g. in <c>${DISTDIR}</c>, see
+<uri link="::ebuild-writing/variables#Predefined Read-Only Variables."/>),
+which makes it hard to have reproducible builds (see
+<uri link="::ebuild-writing/functions/src_unpack/cvs-sources#Disadvantages of CVS Sources"/>).
+Avoid network access in any phase by using local files, extending
+<c>SRC_URI</c> (see
+<uri link="::ebuild-writing/variables#Ebuild-defined Variables"/>), etc.
+</p>
 </body>
 
 <section>


### PR DESCRIPTION
There have been a number of bugs filed to remove network access from
ebuild phases ([1](https://bugs.gentoo.org/show_bug.cgi?id=315403),[2](https://bugs.gentoo.org/show_bug.cgi?id=336771),...), but until now this policy was undocumented
here.  We'll have to relax this restriction if the src_fetch ([3](https://bugs.gentoo.org/show_bug.cgi?id=182028),[4](http://thread.gmane.org/gmane.linux.gentoo.devel/47645/focus=52918),[5](http://thread.gmane.org/gmane.linux.gentoo.devel/87869)) or
pkg_fetch ([6](http://thread.gmane.org/gmane.linux.gentoo.devel/87869/focus=878773)) proposals being discussed for EAPI-6 are accepted, but
neither is currently mentioned in either the PMS (7) or Portage (8).

Yesterday on #gentoo-dev-help:

  16:12 < wking> Can anyone point me to the policy docs for not
    allowing network access (outside of SRC_URI and similar, e.g. from
    src_compile) in ebuilds?  I understand the reason for this, but
    I'd like to link to the official policy from a commit message in
    my overlay.
  16:26 @mrueg wking: i think it is just missing here:
    https://devmanual.gentoo.org/ebuild-writing/functions/src_test/index.html
  16:28 < wking> mrueg: so it's not explicitly documented yet?
  16:29 @mrueg wking: at least i haven't found it 

And in #gentoo-python:

  16:40 < idella4> prometheanfire: where the ***\* does it say in the
    manual no net rule for beyond src_fetch?????
  16:40 < jbergstroem> idella4: do you mean as in no downloading
    stuff? That's been around forever. lemme see if i can find a doc
    reference about it
  16:40 < jbergstroem> idella4: there's been a lot of bugs filed
  16:42 < idella4> thanks jberg
  16:42 < idella4> yes that's the one
  16:43 < jbergstroem> nor sure why it isn't; but it should probably live here 
    https://devmanual.gentoo.org/ebuild-writing/functions/index.html
  16:44 < jbergstroem> and also refr to pkg_fetch
  …
  19:39 < jbergstroem> wking: the devmanual could still benefit from
    being clearer about how/when to fetch sources.  Especially since
    newer packages try to automate suff like this (invoking wget
    from make or whatever for their deps)

7: git://git.overlays.gentoo.org/proj/pms.git
8: git://git.overlays.gentoo.org/proj/portage.git
