### PR TITLE
ebuild-writing/common-mistakes: Mention the 'doc' USE flag

### DIFF
--- a/ebuild-writing/common-mistakes/text.xml
+++ b/ebuild-writing/common-mistakes/text.xml
@@ -391,9 +391,17 @@ implied already, you should only add it if it is something other than
 <body>
 
 <p>
-If your package has documentation, make sure you install it using <c>dodoc</c> 
-or in <path>/usr/share/doc/${PF}</path>. Remember to check for errors when 
+If your package has documentation, make sure you install it using <c>dodoc</c>
+or in <path>/usr/share/doc/${PF}</path>. Remember to check for errors when
 running <c>dodoc</c>/<c>doins</c>.
+</p>
+
+<p>
+If the package documentation is large or requires additional
+dependencies to build, you should make it optional with the <c>doc</c>
+USE flag.  If the documentation is small and does not require
+additional dependencies (e.g. <c>README</c> files), install it
+unconditionally.
 </p>
 
 </body>


### PR DESCRIPTION
When reminding folks to install the docs, also remind them that they
should be using the 'doc' USE flag.  This USE flag is the standard way
to enable/disable doc installation, and we don't want ebuilds blindly
installing docs regardless of how it's set.
