### PR TITLE
general-concepts/licenses: Elaborate on combining licenses

### DIFF
--- a/general-concepts/licenses/text.xml
+++ b/general-concepts/licenses/text.xml
@@ -82,11 +82,34 @@ versions are specified elsewhere.
 </p>
 
 <p>
-Please watch for license conflicts. If the license indicated
-by the package is incompatible with the licenses used by its sources
-(e.g. BSD/MIT package including GPL sources), please contact
-the licenses team for guidance. Do not add packages that seem
-to include license term violations.
+If an installed file is built from sources using different licenses, all those
+licenses must be compatible. The effective license for the file will be the most
+restrictive of input licenses. For example:
+</p>
+
+<ol>
+  <li>
+    If a program includes code that is partially covered by GPL-2
+    and partially by the 3-clause BSD license, the license for
+    the resulting executable will be GPL-2 since it is more restrictive
+    than the other one.
+  </li>
+  <li>
+    If a program includes code that is partially covered by GPL-2+
+    and partially by GPL-3[+], the latter license will be effective
+    since it is the subset of both terms.
+  </li>
+  <li>
+    If a program includes code that is partially covered by GPL-2+
+    and partially by GPL-2, GPL-2 will be the effective subset.
+  </li>
+</ol>
+
+<p>
+Please watch out for license conflicts. If the package combines incompatible
+licenses (e.g. GPL-2 and GPL-3 code without 'or newer' clauses), please contact
+the licenses team for guidance. Do not add packages that seem to include
+license term violations.
 </p>
 
 </body>

--- a/general-concepts/licenses/text.xml
+++ b/general-concepts/licenses/text.xml
@@ -167,6 +167,32 @@ you are unsure as to the meaning of any part of it.
 
 </body>
 </section>
+
+<section>
+<title>Further reading</title>
+<body>
+
+<p>
+The following resources are recommended as source of more information
+on copyright and licensing:
+</p>
+
+<ul>
+  <li>
+    <uri link="https://dwheeler.com/essays/floss-license-slide.html">
+      David A. Wheeler, The Free-Libre / Open Source Software (FLOSS)
+      License Slide
+    </uri>
+  </li>
+  <li>
+    <uri link="https://www.gnu.org/licenses/license-compatibility.en.html">
+      Richard Stallman, License Compatibility and Relicensing
+    </uri>
+  </li>
+</ul>
+
+</body>
+</section>
 </body>
 
 </chapter>


### PR DESCRIPTION
Add a section explaining how to determine the effective license when
a file combines sources with different licenses.  Give explicit examples
with BSD/GPL and GPL/GPL.  Rephrase the license conflict warning to make
it clearer.  Link to GNU's 'License compatibility' article.

Signed-off-by: Michał Górny <mgorny@gentoo.org>