### PR TITLE
general-concepts/mirrors: Clearify that any component in SRC_URI gets mirrored

### DIFF
--- a/general-concepts/mirrors/text.xml
+++ b/general-concepts/mirrors/text.xml
@@ -9,8 +9,9 @@
 <body>
 <p>
 Packages will automatically have their <c>SRC_URI</c> components mirrored onto
-Gentoo mirrors.  When fetching, Portage checks Gentoo mirrors first before
-trying the original upstream location.
+Gentoo mirrors, including components hosted in other Gentoo locations like developer's
+space at <c>dev.gentoo.org</c>, see below.  When fetching, package manager checks
+Gentoo mirrors first before trying the original upstream location.
 </p>
 
 <p>


### PR DESCRIPTION
Clearify that any component in SRC_URI gets mirrored, even those
already hosted in other Gentoo locations, for example files uploaded
to developer's space at dev.gentoo.org.