### PR TITLE
Fix XML structure

### DIFF
--- a/devbook.dtd
+++ b/devbook.dtd
@@ -1,0 +1,98 @@
+<!-- Copyright 2019 Gentoo Authors -->
+<!-- Distributed under the terms of the MIT/X11 license -->
+
+<!-- Document Type Definition for the Gentoo Devmanual -->
+<!-- Based on common.dtd from GuideXML -->
+
+<!ENTITY  % block.class     "p|pre|codesample|note|important|warning|todo
+                                |figure|table|ul|ol|dl
+                                |list-group-u|list-group-d">
+<!ENTITY  % inline.class    "sup|sub|b|c|d|e|path|uri">
+<!ENTITY  % all.class       "%block.class;|%inline.class;">
+
+<!ELEMENT guide         (include|chapter)+>
+<!ATTLIST guide         root (true) #IMPLIED
+                        self CDATA #IMPLIED>
+
+<!ELEMENT include       EMPTY>
+<!ATTLIST include       href CDATA #REQUIRED>
+
+<!ELEMENT chapter       (title, (body|section), section*)>
+<!ELEMENT section       (title, (body|subsection), subsection*)>
+<!ELEMENT subsection    (title, (body|subsubsection), subsubsection*)>
+<!ELEMENT subsubsection (title, body)>
+
+<!-- Title texts are used as anchors, so we shouldn't allow any formatting,
+     but unfortunately it is used in the document. -->
+<!ELEMENT title         (#PCDATA|%inline.class;)*>
+
+<!ELEMENT body          (authors|contentsTree|%block.class;)+>
+
+<!ELEMENT authors       (author)+>
+<!ELEMENT author        (#PCDATA|%inline.class;)*>
+<!ATTLIST author        name  CDATA #REQUIRED
+                        email CDATA #IMPLIED>
+
+<!ELEMENT contentsTree  EMPTY>
+<!ATTLIST contentsTree  maxdepth   CDATA #IMPLIED
+                        root       CDATA #IMPLIED
+                        extraction CDATA #IMPLIED>
+
+<!ELEMENT p             (#PCDATA|%inline.class;)*>
+
+<!ELEMENT pre           (#PCDATA)>
+
+<!ELEMENT codesample    (#PCDATA)>
+<!ATTLIST codesample    lang (c|ebuild|make|m4|sgml) #REQUIRED
+                        numbering (lines) #IMPLIED>
+
+<!ELEMENT note          (#PCDATA|%inline.class;)*>
+<!ELEMENT important     (#PCDATA|%inline.class;)*>
+<!ELEMENT warning       (#PCDATA|%inline.class;)*>
+<!ELEMENT todo          (#PCDATA|%inline.class;)*>
+
+<!ELEMENT figure        EMPTY>
+<!ATTLIST figure        link CDATA #REQUIRED
+                        short CDATA #IMPLIED
+                        caption CDATA #IMPLIED>
+
+<!ELEMENT table         (tcolumn*, tr+)>
+
+<!ELEMENT tcolumn       EMPTY>
+<!ATTLIST tcolumn       width CDATA #REQUIRED>
+
+<!ELEMENT tr            (th|ti)+>
+
+<!ELEMENT th            (#PCDATA|%inline.class;)*>
+<!ATTLIST th            colspan CDATA #IMPLIED
+                        rowspan CDATA #IMPLIED
+                        align (left|center|right) "left">
+
+<!ELEMENT ti            (#PCDATA|%all.class;)*>
+<!ATTLIST ti            colspan CDATA #IMPLIED
+                        rowspan CDATA #IMPLIED
+                        nowrap  CDATA #IMPLIED
+                        align (left|center|right) "left">
+
+<!ELEMENT ul            (li)+>
+<!ELEMENT ol            (li)+>
+<!ELEMENT li            (#PCDATA|%all.class;)*>
+
+<!ELEMENT dl            (dt, dd)+>
+<!ELEMENT dt            (#PCDATA|%inline.class;)*>
+<!-- The following is strange, but devbook.xsl expects only p elements -->
+<!ELEMENT dd            (p)+>
+
+<!ELEMENT list-group-u  (#PCDATA|%all.class;)*>
+<!ELEMENT list-group-d  (#PCDATA|%all.class;)*>
+
+<!ELEMENT sup           (#PCDATA|%inline.class;)*>
+<!ELEMENT sub           (#PCDATA|%inline.class;)*>
+<!ELEMENT b             (#PCDATA|%inline.class;)*>
+<!ELEMENT c             (#PCDATA|%inline.class;)*>
+<!ELEMENT e             (#PCDATA|%inline.class;)*>
+<!ELEMENT path          (#PCDATA|%inline.class;)*>
+<!ELEMENT d             EMPTY>
+
+<!ELEMENT uri           (#PCDATA|%inline.class;)*>
+<!ATTLIST uri           link CDATA #IMPLIED>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -188,7 +188,9 @@
   <xsl:template match="figure">
     <div class="figure">
       <div class="image"><img alt="{@short}" src="{@link}"/></div>
-      <p class="caption"><xsl:value-of select="."/></p>
+      <xsl:if test="@caption">
+        <p class="caption"><xsl:value-of select="@caption"/></p>
+      </xsl:if>
     </div>
   </xsl:template>
 

--- a/general-concepts/autotools/text.xml
+++ b/general-concepts/autotools/text.xml
@@ -42,9 +42,9 @@ together with a few relatively simple upstream-supplied input files, are used to
 create the build system for a package.
 </p>
 
-<figure short="How autotools fits together" link="diagram.png">
-A basic overview of how the main autotools components fit together.
-</figure>
+<figure short="How autotools fits together" link="diagram.png"
+  caption="A basic overview of how the main autotools components fit together."
+  />
 
 <p>
 In a simple setup:

--- a/general-concepts/emerge-and-ebuild/text.xml
+++ b/general-concepts/emerge-and-ebuild/text.xml
@@ -5,8 +5,7 @@
 
 <body>
 
-<figure short="How emerge, ebuild and foo.ebuild interact" link="diagram.png">
-</figure>
+<figure short="How emerge, ebuild and foo.ebuild interact" link="diagram.png" />
 
 <p>
 The <c>emerge</c> program is a high level wrapper for <c>ebuild.sh</c> that handles

--- a/general-concepts/git-to-rsync/text.xml
+++ b/general-concepts/git-to-rsync/text.xml
@@ -29,9 +29,8 @@
   </li>
 </ul>
 
-<figure short="Git to RSYNC Propagation" link="diagram.png">
-  Diagram showing Git to RSYNC Propagation
-</figure>
+<figure short="Git to RSYNC Propagation" link="diagram.png"
+  caption="Diagram showing Git to RSYNC Propagation" />
 
 <p>
   The <c>emerge-websync</c> snapshot is made daily from the staging box.

--- a/general-concepts/mirrors/text.xml
+++ b/general-concepts/mirrors/text.xml
@@ -142,9 +142,8 @@ doing so can cause all kinds of problems with strict firewalls.
 <title>Mirroring Process</title>
 
 <body>
-<figure short="Mirroring Process" link="diagram.png">
-Diagram showing the mirroring process.
-</figure>
+<figure short="Mirroring Process" link="diagram.png"
+  caption="Diagram showing the mirroring process." />
 </body>
 </section>
 


### PR DESCRIPTION
This series of patches is a first attempt to fix the structure of the devmanual. I mainly went by what is actually supported by `devbook.xsl`, and I've changed or dropped those elements and attributes that aren't.

I've also written a preliminary [devbook.dtd](https://gist.github.com/ulm/871338b513483ce0ff45e12295aacfb1) and all files of the document validate with it:
`xmllint --noout --dtdvalid devbook.dtd text.xml`

As is to be expected for a project that has been developed since 10+ years without any formal verification, the resulting rules aren't very strict. For example, there can be formatting elements inside `<title>` when there really shouldn't be, and almost everything is allowed below `<li>` or `<ti>`. We might think about tightening the rules in a second round of updates.
