### PR TITLE
ebuild-maintenance: Moving a package - added missing --signoff switch to git command

### DIFF
--- a/ebuild-maintenance/maintenance-tasks/text.xml
+++ b/ebuild-maintenance/maintenance-tasks/text.xml
@@ -313,7 +313,7 @@ Here is an example where the package
     profiles/package.mask</c>
   </li>
   <li>
-    Commit all the changes in one commit using: <c>git commit --gpg-sign</c>
+    Commit all the changes in one commit using: <c>git commit --gpg-sign -signoff</c>
   </li>
   <li>
     Update any <uri link="::general-concepts/news">news items</uri>
@@ -335,6 +335,8 @@ Author: Guilherme Amadio &lt;amadio@gentoo.org&gt;
 Date:   Tue Nov 3 20:26:52 2015 +0100
 
   media-fonts/nanumfont: renamed to media-fonts/nanum
+  
+  Signed-off-by: Guilherme Amadio &lt;amadio@gentoo.org&gt;
 </pre>
 
 </body>


### PR DESCRIPTION
Moving a package: added --signoff switch to the git command
and corresponding Signed-off-by to the example output so that
git server does not reject the commit as invalid

Signed-off-by: Miroslav Šulc <fordfrog@gentoo.org>