### PR TITLE
ebuild-maintenance fix

### DIFF
--- a/ebuild-maintenance/maintenance-tasks/text.xml
+++ b/ebuild-maintenance/maintenance-tasks/text.xml
@@ -313,7 +313,7 @@ Here is an example where the package
     profiles/package.mask</c>
   </li>
   <li>
-    Commit all the changes in one commit using: <c>git commit --gpg-sign</c>
+    Commit all the changes in one commit using: <c>git commit --gpg-sign --signoff</c>
   </li>
   <li>
     Update any <uri link="::general-concepts/news">news items</uri>
@@ -330,11 +330,13 @@ to the following:
 </p>
 
 <pre>
-commit d391643289097344a0b18ab2665bb26198a0e3a1
-Author: Guilherme Amadio &lt;amadio@gentoo.org&gt;
-Date:   Tue Nov 3 20:26:52 2015 +0100
+commit 7a699bcdce5c1412c02a2aa7717a31bc17c49058
+Author: Miroslav Šulc &lt;fordfrog@gentoo.org&gt;
+Date:   Wed Dec 18 19:56:03 2019 +0100
 
-  media-fonts/nanumfont: renamed to media-fonts/nanum
+    media-libs/libclxclient: moved to x11-libs/libclxclient
+    
+    Signed-off-by: Miroslav Šulc &lt;fordfrog@gentoo.org&gt;
 </pre>
 
 </body>


### PR DESCRIPTION
when moving a package, the git commit command must also
contain --signoff as without it Signed-off-by is not added
to the commit message and git server rejects the commit.
also updated commit message to one that contains
Signed-off-by.

Signed-off-by: Miroslav Šulc <fordfrog@gentoo.org>