### PR TITLE
general-concepts/dependencies: Update for EAPI 7, describe circular deps

### DIFF
--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -622,5 +622,54 @@ DEPEND="test? ( dev-util/foo )"
 
 </body>
 </section>
+
+<section>
+<title>Circular Dependencies</title>
+<body>
+
+<p>
+Circular dependencies occur if one or more of package's (possibly indirect)
+dependencies depend on the package itself. This creates a dependency cycle where
+each of the packages must technically be installed before the other.
+For example, if package A depends on B, B depends on C and C depends on A, then
+the package manager cannot install A before C, and C before A.
+</p>
+
+<p>
+There are three kinds of circular dependencies:
+</p>
+
+<ol>
+  <li>
+    Circular dependencies that occur if only one of the packages strictly needs
+    to be installed before the other. For example, <c>dev-python/certifi</c>
+    strictly requires <c>dev-python/setuptools</c> to build but the latter
+    package requires the former for some runtime functionality. As a result,
+    <c>dev-python/certifi</c> can be installed later than the other package.
+    <c>PDEPEND</c> is used to express this and automatically resolve
+    the circular dependency.
+  </li>
+
+  <li>
+    Circular dependencies that occur if the cycle applies only to some
+    combination of USE flags on one of the packages. For example, running tests
+    in <c>dev-python/setuptools</c> requires a number of packages which require
+    <c>dev-python/setuptools</c> to be installed first. This kind of circular
+    dependency can be resolved by the user by adjusting USE flags on one
+    of the packages, e.g. by disabling tests on <c>dev-python/setuptools</c>,
+    and reenabling them once the dependency is initially installed.
+  </li>
+
+  <li>
+    Circular dependencies that cannot be resolved using the regular means.
+    For example, <c>dev-util/cmake</c> used to depend
+    on <c>dev-libs/jsoncpp</c>, while the latter package used the former
+    to build. Resolving this kind of dependency usually requires bundling one
+    of the dependencies conditionally, or providing an alternate bootstrap path.
+  </li>
+</ol>
+
+</body>
+</section>
 </chapter>
 </guide>

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -12,14 +12,58 @@ provided by <c>emerge</c>.
 </body>
 
 <section>
+<title>CHOST vs CBUILD</title>
+<body>
+
+<p>
+In order to avoid ambiguity, we use the following terms to indicate different
+systems when cross-compiling:
+</p>
+
+<dl>
+  <dt>CBUILD</dt>
+  <dd>
+    The system on which the build is performed.  Dependencies that apply
+    to the CBUILD system can be executed during build time.  When
+    cross-compiling, they are not installed into the system being built.
+  </dd>
+
+  <dt>CHOST</dt>
+  <dd>
+    The system on which the package is going to be executed.  When
+    cross-compiling, dependencies applying to CHOST can not be executed.
+  </dd>
+</dl>
+
+<p>
+When not cross-compiling, CBUILD and CHOST have the same value and both classes
+of dependencies are merged.
+</p>
+
+</body>
+</section>
+
+<section>
 <title>Build Dependencies</title>
 <body>
 
 <p>
-The <c>DEPEND</c> ebuild variable should specify any dependencies which are
-required to unpack, patch, compile or install the package (but see
+Build dependencies are used to specify any dependencies that are required
+to unpack, patch, compile, test or install the package (but see
 <uri link="::general-concepts/dependencies#Implicit System Dependency"/> for
 exemptions).
+</p>
+
+<p>
+Starting with EAPI 7, build dependencies are split into two variables:
+<c>BDEPEND</c> and <c>DEPEND</c>. <c>BDEPEND</c> specifies dependencies
+applicable to CBUILD, i.e. programs that need to be executed during the build,
+e.g. <c>virtual/pkgconfig</c>. <c>DEPEND</c> specifies dependencies for CHOST,
+i.e. packages that need to be found on built system, e.g. libraries and headers.
+</p>
+
+<p>
+In earlier EAPIs, all build dependencies are placed in <c>DEPEND</c>.
 </p>
 
 </body>

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -94,16 +94,14 @@ Items which are in <c>RDEPEND</c> but not <c>DEPEND</c> could <e>in theory</e> b
 </section>
 
 <section>
-<title>Post-Merge Dependencies</title>
+<title>Post Dependencies</title>
 <body>
 
 <p>
-The <c>PDEPEND</c> variable specifies dependencies that should be
-merged <e>after</e> the package, but which may be merged at any time,
-if the former is not possible. This is sometimes used for plugins
-that have a dependency upon the package being merged. Generally
-<c>PDEPEND</c> should be avoided in favour of <c>RDEPEND</c> except
-where this will create circular dependency chains.
+The <c>PDEPEND</c> variable specifies runtime dependencies that do not strictly
+require being satisfied immediately. They can be merged <e>after</e>
+the package. This variable is used purely to resolve circular dependencies,
+while in general case <c>RDEPEND</c> should be used instead.
 </p>
 
 </body>


### PR DESCRIPTION
Multiple improvements to the dependencies chapter:
1. Document `BDEPEND` (with minimal CBUILD/CHOST explanation).
2. Make `PDEPEND` less weird.
3. Remove section on `:` operator, it's not useful for devs.
4. Replace EAPI-conditional implicit RDEPEND explanation with just a minimal warning (we no longer support those old EAPIs).
5. Provide a more detailed section on ciicular deps and how to resolve them.