### PR TITLE
ID attributes should contain only valid characters.

### DIFF
--- a/devbook.xsl
+++ b/devbook.xsl
@@ -278,8 +278,8 @@
 
   <xsl:template name="convert-to-anchor">
     <xsl:param name="data"/>
-    <xsl:variable name="lcletters">abcdefghijklmnopqrstuvwxyz--</xsl:variable>
-    <xsl:variable name="ucletters">ABCDEFGHIJKLMNOPQRSTUVWXYZ<xsl:text> </xsl:text>,</xsl:variable>
+    <xsl:variable name="lcletters">abcdefghijklmnopqrstuvwxyz-</xsl:variable>
+    <xsl:variable name="ucletters">ABCDEFGHIJKLMNOPQRSTUVWXYZ<xsl:text> </xsl:text></xsl:variable>
     <xsl:variable name="lcdata" select="translate(normalize-space($data), $ucletters, $lcletters)"/>
     <!-- Delete anything but letters, digits, hyphen, dot, underscore -->
     <xsl:variable name="allowed">abcdefghijklmnopqrstuvwxyz0123456789-._</xsl:variable>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -280,7 +280,10 @@
     <xsl:param name="data"/>
     <xsl:variable name="lcletters">abcdefghijklmnopqrstuvwxyz--</xsl:variable>
     <xsl:variable name="ucletters">ABCDEFGHIJKLMNOPQRSTUVWXYZ<xsl:text> </xsl:text>,</xsl:variable>
-    <xsl:value-of select="translate(normalize-space($data),$ucletters,$lcletters)"/>
+    <xsl:variable name="lcdata" select="translate(normalize-space($data), $ucletters, $lcletters)"/>
+    <!-- Delete anything but letters, digits, hyphen, dot, underscore -->
+    <xsl:variable name="allowed">abcdefghijklmnopqrstuvwxyz0123456789-._</xsl:variable>
+    <xsl:value-of select="translate($lcdata, translate($lcdata, $allowed, ''), '')"/>
   </xsl:template>
 
   <xsl:template match="uri">


### PR DESCRIPTION
Keep only characters that HTML 4 allows in ID attributes (but exclude the colon as well). Note that HTML 5 is more sloppy and would permit characters outside of the ASCII range, but these won't be valid in URI fragment identifiers (RFC 3986).
