### PR TITLE
Make (sub-)section titles unique within each chapter.

### DIFF
--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -137,7 +137,7 @@ IUSE="foo +bar"
 <title>EAPI=2</title>
 
 <subsection>
-<title>Helpers</title>
+<title>EAPI 2 Helpers</title>
 <body>
 <ul>
 	<li>
@@ -158,7 +158,7 @@ doman foo.lang.1
 </subsection>
 
 <subsection>
-<title>Metadata</title>
+<title>EAPI 2 Metadata</title>
 <body>
 <ul>
 	<li>
@@ -234,7 +234,7 @@ SRC_URI="https://dl.google.com/earth/client/GE4/release_4_3/GoogleEarthLinux.bin
 </subsection>
 
 <subsection>
-<title>Phases</title>
+<title>EAPI 2 Phases</title>
 <body>
 <ul>
 	<li>
@@ -346,7 +346,7 @@ src_compile() {
 <title>EAPI=4</title>
 
 <subsection>
-<title>Helpers</title>
+<title>EAPI 4 Helpers</title>
 <body>
 <ul>
 	<li>
@@ -470,7 +470,7 @@ src_install() {
 </subsection>
 
 <subsection>
-<title>Metadata</title>
+<title>EAPI 4 Metadata</title>
 <body>
 <ul>
 	<li>
@@ -494,7 +494,7 @@ DEPEND="
 </subsection>
 
 <subsection>
-<title>Phases</title>
+<title>EAPI 4 Phases</title>
 <body>
 <ul>
 	<li>
@@ -577,7 +577,7 @@ src_install() {
 </subsection>
 
 <subsection>
-<title>Variables</title>
+<title>EAPI 4 Variables</title>
 <body>
 <ul>
 	<li>
@@ -668,7 +668,7 @@ src_install() {
 <title>EAPI=5</title>
 
 <subsection>
-<title>Metadata</title>
+<title>EAPI 5 Metadata</title>
 <body>
 <ul>
 	<li>
@@ -731,7 +731,7 @@ RDEPEND="dev-libs/foo:2=
 </subsection>
 
 <subsection>
-<title>Profiles</title>
+<title>EAPI 5 Profiles</title>
 <body>
 <ul>
 	<li>
@@ -745,7 +745,7 @@ RDEPEND="dev-libs/foo:2=
 </subsection>
 
 <subsection>
-<title>Helpers</title>
+<title>EAPI 5 Helpers</title>
 <body>
 <ul>
 	<li>
@@ -788,7 +788,7 @@ If USE flag is set, echo [true output][true suffix] (defaults to "yes"),
 </subsection>
 
 <subsection>
-<title>Phases</title>
+<title>EAPI 5 Phases</title>
 <body>
 <ul>
 	<li>
@@ -802,7 +802,7 @@ If USE flag is set, echo [true output][true suffix] (defaults to "yes"),
 </subsection>
 
 <subsection>
-<title>Variables</title>
+<title>EAPI 5 Variables</title>
 <body>
 <ul>
 	<li>
@@ -821,14 +821,14 @@ If USE flag is set, echo [true output][true suffix] (defaults to "yes"),
 <title>EAPI=6</title>
 
 <subsection>
-<title>Bash version</title>
+<title>EAPI 6 Bash version</title>
 <body>
 <p>Ebuilds can use features of Bash version 4.2 (was 3.2 before).</p>
 </body>
 </subsection>
 
 <subsection>
-<title>Ebuild environment</title>
+<title>EAPI 6 Ebuild Environment</title>
 <body>
 <ul>
 	<li>
@@ -850,7 +850,7 @@ If USE flag is set, echo [true output][true suffix] (defaults to "yes"),
 </subsection>
 
 <subsection>
-<title>Phases</title>
+<title>EAPI 6 Phases</title>
 <body>
 <ul>
 	<li>
@@ -888,7 +888,7 @@ src_install() {
 </subsection>
 
 <subsection>
-<title>Helpers</title>
+<title>EAPI 6 Helpers</title>
 <body>
 <ul>
 	<li>
@@ -963,7 +963,7 @@ src_install() {
 <title>EAPI=7</title>
 
 <subsection>
-<title>Terminology</title>
+<title>EAPI 7 Terminology</title>
 <body>
 <p>Documents may use the following terms to better describe dependency and installation targets.</p>
 <ul>
@@ -983,7 +983,7 @@ src_install() {
 </body>
 </subsection>
 <subsection>
-<title>Variables</title>
+<title>EAPI 7 Variables</title>
 <body>
 <ul>
 	<li>
@@ -1030,7 +1030,7 @@ src_install() {
 </body>
 </subsection>
 <subsection>
-<title>Metadata</title>
+<title>EAPI 7 Metadata</title>
 <body>
 <ul>
 	<li>
@@ -1045,7 +1045,7 @@ src_install() {
 </body>
 </subsection>
 <subsection>
-<title>Profiles</title>
+<title>EAPI 7 Profiles</title>
 <body>
 <ul>
 	<li>
@@ -1056,7 +1056,7 @@ src_install() {
 </body>
 </subsection>
 <subsection>
-<title>Helpers</title>
+<title>EAPI 7 Helpers</title>
 <body>
 <ul>
 	<li>

--- a/ebuild-writing/functions/src_compile/text.xml
+++ b/ebuild-writing/functions/src_compile/text.xml
@@ -31,9 +31,10 @@
 <section>
 <title>Default <c>src_compile</c></title>
 
-<subsection>
-<title>with EAPI=0,1</title>
 <body>
+<ul>
+<li>
+<p>with EAPI=0,1</p>
 <codesample lang="ebuild">
 src_compile() {
 	if [ -x ./configure ]; then
@@ -44,11 +45,10 @@ src_compile() {
 	fi
 }
 </codesample>
-</body>
-</subsection>
-<subsection>
-<title>with EAPI=2</title>
-<body>
+</li>
+
+<li>
+<p>with EAPI=2</p>
 <codesample lang="ebuild">
 src_compile() {
 	if [ -f Makefile ] || [ -f GNUmakefile ] || [ -f makefile ]; then
@@ -56,16 +56,18 @@ src_compile() {
 	fi
 }
 </codesample>
+</li>
+</ul>
 </body>
-</subsection>
 </section>
 
 <section>
 <title>Sample <c>src_compile</c></title>
 
-<subsection>
-<title>with EAPI=0</title>
 <body>
+<ul>
+<li>
+<p>with EAPI=0</p>
 <codesample lang="ebuild">
 src_compile() {
 	use sparc &amp;&amp; filter-flags -fomit-frame-pointer
@@ -81,18 +83,18 @@ src_compile() {
 <note>
 You also need to inherit the <uri link="::eclass-reference/flag-o-matic.eclass/">flag-o-matic</uri> eclass in order to use the <c>append-ldflags</c> function.
 </note>
-</body>
-</subsection>
-<subsection>
-<title>with EAPI=2</title>
-<body>
+</li>
+
+<li>
+<p>with EAPI=2</p>
 <p>
-porting the above example to EAPI=2, you won't need to define an extra
+Porting the above example to EAPI=2, you won't need to define an extra
 <c>src_compile</c>, as it only calls <c>emake</c> (which is the default
 <c>src_compile</c> function).
 </p>
+</li>
+</ul>
 </body>
-</subsection>
 </section>
 
 <section>


### PR DESCRIPTION
Section, subsection, etc. titles are used to construct ID attributes,
which must be unique within each chapter.

One approach to disambiguate these identifiers would be to use the
complete section hierarchy for constructing them (see bug 626032).
However, that would break external references (and for example, links
from bugzilla or from mailing list archives cannot be updated).

Use a less intrusive approach instead and make the titles of the few
ambiguous subsections unique, or convert them to a list.

Closes: https://bugs.gentoo.org/626032
Signed-off-by: Ulrich Müller <ulm@gentoo.org>