### PR TITLE
Repoman-related cleanup + Manifests

### DIFF
--- a/general-concepts/manifest/text.xml
+++ b/general-concepts/manifest/text.xml
@@ -15,7 +15,9 @@ by the package. This is used to verify integrity upon fetching them.
 </p>
 
 <p>
-To generate the <c>Manifest</c>, use <c>ebuild foo.ebuild manifest</c>.
+To generate the <c>Manifest</c>, use <c>ebuild foo.ebuild manifest</c>
+or <c>repoman manifest</c>. You may want to set <c>GENTOO_MIRRORS=</c> while
+calling it to fetch distfiles from their original locations immediately.
 </p>
 </body>
 </section>

--- a/general-concepts/manifest/text.xml
+++ b/general-concepts/manifest/text.xml
@@ -7,68 +7,15 @@
 <title>Generating the Manifest</title>
 <body>
 <p>
-In the tree, every package has a <c>Manifest</c> file. This file lives in the same
-directory as the ebuilds for the package. The <c>Manifest</c> file contains digests
-(currently RMD160, SHA1, SHA256, SHA512 and WHIRLPOOL) and file size data for every
-file in the directory and any subdirectories. This is used to verify integrity.
-The <c>Manifest</c> may also be digitally signed.
+In the tree, every package has a <c>Manifest</c> file. This file lives
+in the same directory as the ebuilds for the package. The <c>Manifest</c> file
+contains digests (the current list can be found in <c>metadata/layout.conf</c>
+as <c>manifest-hashes</c>) and file size data for every distfile used
+by the package. This is used to verify integrity upon fetching them.
 </p>
 
 <p>
-To generate the <c>Manifest</c>, use <c>ebuild foo.ebuild manifest</c>. When
-committing, the <c>Manifest</c> file must be regenerated to handle any
-changes <d/> <c>repoman</c> will do this automatically.
-</p>
-</body>
-</section>
-
-<section>
-<title>Signing the Manifest using your GPG key</title>
-<body>
-<p>
-Requirements:
-</p>
-
-<ul>
-  <li>&gt;=sys-apps/portage-2.0.51_pre10</li>
-  <li>&gt;=app-crypt/gnupg-1.2.4</li>
-</ul>
-
-<p>
-Key Setup:
-</p>
-
-<ul>
-  <li>
-    <uri link="https://www.gentoo.org/doc/en/gnupg-user.xml#doc_chap2">Create</uri>
-    a new DSA GnuPG key with at least a 1024 bit keylength, an expiration
-    period no longer than 6 months and a good passphrase.
-  </li>
-  <li>
-    <uri link="https://www.gentoo.org/doc/en/gnupg-user.xml#doc_chap3">Upload</uri>
-    the key to a keyserver.
-  </li>
-</ul>
-
-<p>
-Portage Configuration:
-</p>
-
-<ul>
-  <li>
-    Set <c>PORTAGE_GPG_DIR</c> to your <c>~/.gnupg/</c> directory
-    (or the directory where the keyring with your new key is).
-  </li>
-  <li>Set <c>PORTAGE_GPG_KEY</c> to the key id of your new key.</li>
-  <li>Set FEATURES="sign".</li>
-</ul>
-
-<p>
-Now you should be able to sign your Manifests on repoman commit. Repoman will
-ask you for your passphrase before committing the Manifest. This step is
-<e>after</e> it has committed the other files. At the moment repoman doesn't
-check if the Manifest is already signed, so others are able to "unsign" your
-package later. This will change before signing is made mandatory.
+To generate the <c>Manifest</c>, use <c>ebuild foo.ebuild manifest</c>.
 </p>
 </body>
 </section>

--- a/general-concepts/manifest/text.xml
+++ b/general-concepts/manifest/text.xml
@@ -20,6 +20,26 @@ or <c>repoman manifest</c>. You may want to set <c>GENTOO_MIRRORS=</c> while
 calling it to fetch distfiles from their original locations immediately.
 </p>
 </body>
+
+<subsection>
+<title>Thin and thick Manifests</title>
+<body>
+<p>
+There are two kinds of Manifest files in Gentoo: thin Manifests that are used
+in the development repositories, and thick Manifests that are distributed
+via rsync to end users. Thin Manifests are described above.
+</p>
+
+<p>
+Thick Manifests add checksums for all files in the repository, and an OpenPGP
+signature. This provides both for integrity and authenticity checking when
+the repository is transmitted over insecure channels. Thick Manifests
+are automatically generated on Gentoo Infrastructure, and require no specific
+action from developers.
+</p>
+</body>
+</subsection>
+
 </section>
 </chapter>
 </guide>


### PR DESCRIPTION
Started as cleanup of repoman mentions but also found really stale Manifest mentions.

Specifically:
* <del>Remove duplicate mentions of `repoman commit`. I want to confine them to a single chapter, then replace altogether.</del>
* Remove a lot of stale information about thick Manifests.
* Mention that manifests can be regened via `repoman manifest` (over `ebuild ... manifest`).