### PR TITLE
ebuild-writing/.../metadata: clarify that upstream maintainer takes no 'type'

### DIFF
--- a/ebuild-writing/misc-files/metadata/text.xml
+++ b/ebuild-writing/misc-files/metadata/text.xml
@@ -174,6 +174,8 @@ metadata.xml:
     Provides information about the upstream maintainer. It requires a
     &lt;name&gt; subtag to be specified, supports an optional
     &lt;email&gt; subtag and an optional <c>status</c> attribute.
+    Note that the <c>type</c> attribute <e>must not</e> be specified
+    for upstream maintainers.
   </ti>
 </tr>
 <tr>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/703626
Closes: https://github.com/gentoo/devmanual/pull/140
Signed-off-by: Göktürk Yüksek <gokturk@gentoo.org>