### PR TITLE
More postprocessing of man2html output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 XMLS := $(shell find . -name .git -prune -o -type f -name 'text.xml' -print)
 SVGS := $(shell find . -name .git -prune -o -type f -name '*.svg' -print)
 HTMLS := $(subst text.xml,index.html,$(XMLS))
+ECLASS_HTMLS := $(wildcard eclass-reference/*/index.html)
 IMAGES := $(patsubst %.svg,%.png,$(SVGS))
 
 all: prereq validate $(HTMLS) $(IMAGES) documents.js
@@ -52,9 +53,9 @@ validate: prereq
 # Run app-text/tidy-html5 on the output to detect mistakes.
 # We have to loop through them because otherwise tidy won't
 # tell you which file contains a mistake.
-tidy: $(HTMLS)
+tidy: $(HTMLS) $(ECLASS_HTMLS)
 	@status=0; \
-	for f in $(HTMLS); do \
+	for f in $^; do \
 	  output=$$(tidy -q -errors --drop-empty-elements no $${f} 2>&1) \
 	  || { status=$$?; echo "Failed on $${f}:"; echo "$${output}"; }; \
 	done; \

--- a/bin/gen-eclass-html.sh
+++ b/bin/gen-eclass-html.sh
@@ -105,11 +105,13 @@ for i in $(/usr/bin/qlist eclass-manpages) /usr/share/man/man5/ebuild.5*; do
 	# rebuild the man page each time
 	echo -n "${HEADER//@TITLE@/${BASENAME}}" > "${FINAL}"
 	# generate html pages and fix hyperlinks for eclass and ebuild man pages
-	${DECOMPRESS} "${i}" | /usr/bin/man2html -r - \
+	${DECOMPRESS} "${i}" | /usr/bin/man2html -r \
 	| sed -e '1,/<BODY>/d;/<\/BODY>/,$d' \
 		-e '/<A HREF=/s:"\.\./man5/\([^"]*eclass\|ebuild\)\.5\.html":"../\1/index.html":g' \
 		-e 's:<A HREF="\.\./man[^"]*">\([^<>]*\)</A>:\1:g' \
 		-e 's:<A HREF="[^"]*//localhost/[^"]*">\([^<>]*\)</A>:\1:g' \
+		-e 's:<A HREF="[^"]*\${[^"]*">\([^<>]*\)</A>:\1:g' \
+		-e 's:<TT>\([^<>]*\)</TT>:\1:g' \
 		>> "${FINAL}"
 	echo -n "${FOOTER}" >> "${FINAL}"
 done


### PR DESCRIPTION
Running "tidy" on the html files generated from eclass manpages produced several warnings. Add some additional postprocessing to reduce their number.

Some warnings for `fortran-2.eclass` and `multilib-build.eclass` remain. They are caused by malformed eclass documentation (already fixed in the tree) and should go away after the next release of app-doc/eclass-manpages.
