### PR TITLE
appendices/editor-configuration: Drop outdated to-do item.

### DIFF
--- a/appendices/editor-configuration/text.xml
+++ b/appendices/editor-configuration/text.xml
@@ -5,13 +5,9 @@
 <body>
 
 <p>
-This section provides hints as to how to configue your text editor for working with ebuilds.
+This section provides hints as to how to configue your text editor for working
+with ebuilds.
 </p>
-
-<todo>
-from vapier:  add a section for nano ... users just have to copy
-/etc/nanorc to ~/.nanorc and uncomment the sections for ebuilds
-</todo>
 
 </body>
 


### PR DESCRIPTION
This no longer applies, ebuild specific sections have been removed from nanorc in 2015.
