### PR TITLE
Links to eclass references

### DIFF
--- a/appendices/contributors/text.xml
+++ b/appendices/contributors/text.xml
@@ -16,8 +16,7 @@ This page lists the contributions to the Gentoo Development Guide:
   <uri link="::tools-reference/cat/#Here Documents"/>
 </author>
 <author name="Aaron Walker" email="ka0ttic@gentoo.org">
-  <uri link="::tasks-reference/completion"/>,
-  <uri link="::eclass-reference/subversion.eclass"/>
+  <uri link="::tasks-reference/completion"/>
 </author>
 <author name="Robert Coie" email="rac@gentoo.org">
   <uri link="::appendices/editor-configuration/xemacs"/>

--- a/appendices/contributors/text.xml
+++ b/appendices/contributors/text.xml
@@ -17,7 +17,7 @@ This page lists the contributions to the Gentoo Development Guide:
 </author>
 <author name="Aaron Walker" email="ka0ttic@gentoo.org">
   <uri link="::tasks-reference/completion"/>,
-  <uri link="::eclass-reference/subversion.eclass">subversion.eclass</uri>
+  <uri link="::eclass-reference/subversion.eclass"/>
 </author>
 <author name="Robert Coie" email="rac@gentoo.org">
   <uri link="::appendices/editor-configuration/xemacs"/>

--- a/bin/gen-eclass-html.sh
+++ b/bin/gen-eclass-html.sh
@@ -141,7 +141,7 @@ installed by emerging <c>app-doc/eclass-manpages</c>.
 EOF
 
 for i in $(find $OUTPUTDIR/ -maxdepth 1 -mindepth 1 -type d | sort); do
-	echo "<li><uri link=\"$(basename $i)/index.html\">$(basename $i) Reference</uri></li>" >> ${OUTPUTDIR}/text.xml
+	echo "<li><uri link=\"$(basename $i)/index.html\">$(basename $i)</uri></li>" >> ${OUTPUTDIR}/text.xml
 done
 
 cat << EOF >> ${OUTPUTDIR}/text.xml

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -329,6 +329,12 @@
               <xsl:when test=". != ''">
                 <a class="{$class}" href="{concat($relative_path_depth_recursion, substring-after(@link, '::'), $slash, 'index.html')}"><xsl:value-of select="."/></a>
               </xsl:when>
+              <xsl:when test="starts-with(@link, '::eclass-reference/') and substring-after(@link, '::eclass-reference/') != ''">
+                <!-- Eclass reference pages are generated with man2html,
+                     so there isn't any text.xml that could be loaded.
+                     Use the name of the eclass as link text. #442194 -->
+                <a class="{$class}" href="{concat($relative_path_depth_recursion, substring-after(@link, '::'), $slash, 'index.html')}"><xsl:value-of select="substring-before(concat(substring-after(@link, '::eclass-reference/'), $slash), '/')"/></a>
+              </xsl:when>
               <xsl:otherwise>
                 <a class="{$class}" href="{concat($relative_path_depth_recursion, substring-after(@link, '::'), $slash, 'index.html')}"><xsl:value-of select="document(concat(/guide/@self, $relative_path_depth_recursion, substring-after(@link, '::'), '/text.xml'))/guide/chapter[1]/title"/></a>
               </xsl:otherwise>

--- a/ebuild-writing/functions/src_compile/build-environment/text.xml
+++ b/ebuild-writing/functions/src_compile/build-environment/text.xml
@@ -141,7 +141,7 @@ functions can be used here.
 </codesample>
 
 <p>
-See <uri link="::eclass-reference/flag-o-matic.eclass/">flag-o-matic.eclass</uri> for a full reference.
+See <uri link="::eclass-reference/flag-o-matic.eclass/"/> for a full reference.
 </p>
 </body>
 </section>

--- a/ebuild-writing/functions/src_compile/building/text.xml
+++ b/ebuild-writing/functions/src_compile/building/text.xml
@@ -34,8 +34,9 @@ some MIPS and SPARC systems.
 <p>
 Sometimes a package will try to use a bizarre compiler, or will need to be told
 which compiler to use. In these situations, the <c>tc-getCC()</c> function from
-<uri link="::eclass-reference/toolchain-funcs.eclass/">toolchain-funcs.eclass</uri> should be used. Other similar functions are available
-<d/> these are documented in <c>man toolchain-funcs.eclass</c>.
+<uri link="::eclass-reference/toolchain-funcs.eclass/"/> should be used.
+Other similar functions are available <d/> these are documented in
+<c>man toolchain-funcs.eclass</c>.
 </p>
 
 <note>

--- a/ebuild-writing/functions/src_unpack/svn-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/svn-sources/text.xml
@@ -6,7 +6,7 @@
 <body>
 <p>
 As with CVS, an eclass exists for working directly with upstream
-Subversion repositories. See <uri link="::eclass-reference/subversion.eclass/">subversion.eclass</uri>
+Subversion repositories. See <uri link="::eclass-reference/subversion.eclass/"/>
 for a full list of functions and variables. Also see
 the <uri link="::ebuild-writing/functions/src_unpack/cvs-sources"/> 
 section.
@@ -89,7 +89,7 @@ following variables are also noteworthy:
 </table>
 
 <p>
-See the eclass itself and <uri link="::eclass-reference/subversion.eclass/">subversion.eclass</uri>
+See the eclass itself and <uri link="::eclass-reference/subversion.eclass/"/>
 for the full range of options. To perform the actual checkout, use
 the <c>subversion_src_unpack</c> function, which calls
 both <c>subversion_svn_fetch</c> and <c>subversion_bootstrap</c>

--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -7,7 +7,7 @@
 <p>
 An eclass is a collection (library) of functions or functionality that is shared
 between packages. See <uri link="::eclass-writing/" /> for the full story on what
-eclasses can do, how they work and how to write them, and <uri link="::eclass-reference/">the eclass reference</uri>
+eclasses can do, how they work and how to write them, and <uri link="::eclass-reference/"/>
 for documentation on various commonly used eclasses. This section only explains
 how to use an eclass which has already been written.
 </p>
@@ -78,10 +78,10 @@ Note the <c>inherit</c> immediately after the header.
 </p>
 
 <p>
-The <c>autotools</c> eclass (see <uri link="::eclass-reference/autotools.eclass/">autotools.eclass</uri>) is needed to get the
+The <c>autotools</c> eclass (see <uri link="::eclass-reference/autotools.eclass/"/>) is needed to get the
 <c>eautoreconf</c> function.  The <c>flag-o-matic</c> eclass (see <uri
-link="::eclass-reference/flag-o-matic.eclass/">flag-o-matic.eclass</uri>) is needed for <c>replace-flags</c>, and
-the <c>bash-completion-r1</c> eclass (<uri link="::eclass-reference/bash-completion-r1.eclass/">bash-completion-r1.eclass</uri>) is used
+link="::eclass-reference/flag-o-matic.eclass/"/>) is needed for <c>replace-flags</c>, and
+the <c>bash-completion-r1</c> eclass (<uri link="::eclass-reference/bash-completion-r1.eclass/"/>) is used
 to handle the bash completion file via <c>dobashcomp</c>.
 </p>
 

--- a/tasks-reference/completion/text.xml
+++ b/tasks-reference/completion/text.xml
@@ -8,8 +8,7 @@
 Since v2.05a, <c>bash</c> has offered intelligent programmable completion.  Writing
 such completions for your own programs/things you maintain is relatively easy
 provided you know bash already. See
-<uri link="::eclass-reference/bash-completion-r1.eclass/">
-bash-completion-r1.eclass</uri>
+<uri link="::eclass-reference/bash-completion-r1.eclass/"/>
 for how to install completion files.
 </p>
 </body>


### PR DESCRIPTION
Fix links to eclass reference pages, which wasn't working since the transition to auto-generated pages.

This allows to revert the earlier workaround that had changed all references in the text.
