### PR TITLE
Support offline browsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ HTMLS := $(subst text.xml,index.html,$(XMLS))
 ECLASS_HTMLS := $(wildcard eclass-reference/*/index.html)
 IMAGES := $(patsubst %.svg,%.png,$(SVGS))
 
+# Nonzero value disables external assets for offline browsing.
+OFFLINE = 0
+
 all: prereq validate build documents.js
 
 prereq:
@@ -49,7 +52,7 @@ documents.js: bin/build_search_documents.py $(XMLS)
 #
 .SECONDEXPANSION:
 %.html: $$(dir $$@)text.xml devbook.xsl xsl/*.xsl $$(subst text.xml,index.html,$$(wildcard $$(dir $$@)*/text.xml))
-	xsltproc devbook.xsl $< > $@
+	xsltproc --param offline "$(OFFLINE)" devbook.xsl $< > $@
 
 validate: prereq
 	@xmllint --noout --dtdvalid devbook.dtd $(XMLS) \

--- a/bin/gen-eclass-html.sh
+++ b/bin/gen-eclass-html.sh
@@ -47,12 +47,13 @@ IFS='' read -r -d '' HEADER << 'EOF'
 <li><a href="/index.html"><i class="fa fa-home"></i>  Home</a></li>
 <li><a href="../index.html"><i class="fa fa-arrow-up"></i>  Eclass Reference</a></li>
 </ul></div>
-</div></div></nav></header><div class="container"><div class="row"><div class="col-md010"><ol class="breadcrumb"><li><a href="/index.html">Master Index</a></li><li><a href="../index.html">Eclass Reference</a></li></ol></div></div></div>
-	<div class="container">
+</div></div></nav>
+<div class="container"><div class="row"><div class="col-md010"><ol class="breadcrumb"><li><a href="/index.html">Master Index</a></li><li><a href="../index.html">Eclass Reference</a></li></ol></div></div></div></header>
+<main><div class="container">
 EOF
 
 IFS='' read -r -d '' FOOTER << 'EOF'
-</div>
+</div></main>
 <footer><div class="container">
 <div class="row">
 <div class="col-xs-12 col-md-offset-2 col-md-7"></div>

--- a/bin/gen-eclass-html.sh
+++ b/bin/gen-eclass-html.sh
@@ -37,7 +37,7 @@ IFS='' read -r -d '' HEADER << 'EOF'
 </ul>
 </div>
 </div></div>
-<div class="logo">
+<div>
 <a href="/" title="Back to the homepage" class="site-logo"><object data="https://assets.gentoo.org/tyrian/site-logo.svg" type="image/svg+xml"><img src="https://assets.gentoo.org/tyrian/site-logo.png" alt="Gentoo Linux Logo"></object></a><span class="site-label">Development Guide</span>
 </div>
 </div></div></div>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -14,6 +14,10 @@
 
 <xsl:output method="html" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
 
+<!-- When true, disable external assets for offline browsing.
+     The parameter can be passed with "xsltproc -\-param offline 1". -->
+<xsl:param name="offline" select="0"/>
+
 <xsl:variable name="newline">
 <xsl:text>
 </xsl:text>
@@ -451,13 +455,21 @@
       <title><xsl:value-of select="/guide/chapter[1]/title"/> – Gentoo Development Guide</title>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta name="description" content="The Gentoo Devmanual is a technical manual which covers topics such as writing ebuilds and eclasses, and policies that developers should be abiding by." />
-      <link href="https://assets.gentoo.org/tyrian/bootstrap.min.css" rel="stylesheet" media="screen" />
-      <link href="https://assets.gentoo.org/tyrian/tyrian.min.css" rel="stylesheet" media="screen" />
+      <xsl:choose>
+        <xsl:when test="$offline">
+          <link rel="stylesheet" href="{$relative_path_depth_recursion}offline.css" type="text/css" />
+        </xsl:when>
+        <xsl:otherwise>
+          <link href="https://assets.gentoo.org/tyrian/bootstrap.min.css" rel="stylesheet" media="screen" />
+          <link href="https://assets.gentoo.org/tyrian/tyrian.min.css" rel="stylesheet" media="screen" />
+        </xsl:otherwise>
+      </xsl:choose>
       <link rel="stylesheet" href="{$relative_path_depth_recursion}devmanual.css" type="text/css" />
       <link rel="icon" href="https://www.gentoo.org/favicon.ico" type="image/x-icon" />
     </head>
     <body>
       <header>
+        <xsl:if test="not($offline)">
         <div class="site-title">
           <div class="container">
             <div class="row">
@@ -561,6 +573,7 @@
             </div>
           </div>
         </div>
+        </xsl:if>
         <div class="container">
           <div class="row">
             <div class="col-md010">
@@ -581,20 +594,24 @@
       </main>
       <footer>
         <div class="container">
-          <div class="row">
-            <div class="col-xs-12 col-md-offset-2 col-md-7">
+          <xsl:if test="not($offline)">
+            <div class="row">
+              <div class="col-xs-12 col-md-offset-2 col-md-7">
+              </div>
+              <div class="col-xs-12 col-md-3">
+                <h3 class="footerhead">Questions or comments?</h3>
+                Please feel free to <a href="https://www.gentoo.org/inside-gentoo/contact/">contact us</a>.
+              </div>
             </div>
-            <div class="col-xs-12 col-md-3">
-              <h3 class="footerhead">Questions or comments?</h3>
-              Please feel free to <a href="https://www.gentoo.org/inside-gentoo/contact/">contact us</a>.
-            </div>
-          </div>
+          </xsl:if>
           <div class="row">
             <div class="col-xs-2 col-sm-3 col-md-2">
-              <ul class="footerlinks three-icons">
-                <li><a href="https://twitter.com/gentoo" title="@Gentoo on Twitter"><span class="fa fa-twitter fa-fw"></span></a></li>
-                <li><a href="https://www.facebook.com/gentoo.org" title="Gentoo on Facebook"><span class="fa fa-facebook fa-fw"></span></a></li>
-              </ul>
+              <xsl:if test="not($offline)">
+                <ul class="footerlinks three-icons">
+                  <li><a href="https://twitter.com/gentoo" title="@Gentoo on Twitter"><span class="fa fa-twitter fa-fw"></span></a></li>
+                  <li><a href="https://www.facebook.com/gentoo.org" title="Gentoo on Facebook"><span class="fa fa-facebook fa-fw"></span></a></li>
+                </ul>
+              </xsl:if>
             </div>
             <div class="col-xs-10 col-sm-9 col-md-10">
               <strong>Copyright (C) 2001-2020 Gentoo Authors</strong><br />
@@ -608,11 +625,13 @@
           </div>
         </div>
       </footer>
-      <script src="https://assets.gentoo.org/tyrian/jquery.min.js"></script>
-      <script src="https://assets.gentoo.org/tyrian/bootstrap.min.js"></script>
-      <script src="https://assets.gentoo.org/lunr/lunr.min.js"></script>
-      <script><xsl:text>var documentsSrc = "</xsl:text><xsl:value-of select="$relative_path_depth_recursion"/><xsl:text>documents.js"</xsl:text></script>
-      <script src="{$relative_path_depth_recursion}search.js"></script>
+      <xsl:if test="not($offline)">
+        <script src="https://assets.gentoo.org/tyrian/jquery.min.js"></script>
+        <script src="https://assets.gentoo.org/tyrian/bootstrap.min.js"></script>
+        <script src="https://assets.gentoo.org/lunr/lunr.min.js"></script>
+        <script><xsl:text>var documentsSrc = "</xsl:text><xsl:value-of select="$relative_path_depth_recursion"/><xsl:text>documents.js"</xsl:text></script>
+        <script src="{$relative_path_depth_recursion}search.js"></script>
+      </xsl:if>
     </body>
     </html>
   </xsl:template>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -542,48 +542,50 @@
                 </button>
               </div>
               <div class="collapse navbar-collapse" id="gw-toolbar">
-              <div class="input-group">
-                <input type="search" name="search" placeholder="Search" title="Search Gentoo Developer Manual [f]" accesskey="f" id="searchInput" class="form-control" onclick="fetchDocuments()"/>
-                <div class="input-group-btn">
-                  <input type="submit" name="fulltext" value="Search" title="Search the pages for this text" id="mw-searchButton" class="searchButton btn btn-default" onclick="search()"/>
+                <div class="input-group">
+                  <input type="search" name="search" placeholder="Search" title="Search Gentoo Developer Manual [f]" accesskey="f" id="searchInput" class="form-control" onclick="fetchDocuments()"/>
+                  <div class="input-group-btn">
+                    <input type="submit" name="fulltext" value="Search" title="Search the pages for this text" id="mw-searchButton" class="searchButton btn btn-default" onclick="search()"/>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </nav>
-      </header>
-      <div id="searchResults" class="modal fade" role="dialog">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
+        </nav>
+        <div id="searchResults" class="modal fade" role="dialog">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
               <button type="button" class="close" data-dismiss="modal">x</button>
               <h4 class="modal-title">Search Results</h4>
-            </div>
-            <div class="modal-body">
-              <p>No results found.</p>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+              <div class="modal-body">
+                <p>No results found.</p>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="container">
-        <div class="row">
-          <div class="col-md010">
-            <ol class="breadcrumb">
-              <xsl:call-template name="printParentDocs">
-                <xsl:with-param name="path" select="/guide/@self"/>
-                <xsl:with-param name="depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/' , ''))"/>
-              </xsl:call-template>
-            </ol>
+        <div class="container">
+          <div class="row">
+            <div class="col-md010">
+              <ol class="breadcrumb">
+                <xsl:call-template name="printParentDocs">
+                  <xsl:with-param name="path" select="/guide/@self"/>
+                  <xsl:with-param name="depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/' , ''))"/>
+                </xsl:call-template>
+              </ol>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="container">
-        <xsl:apply-templates/>
-      </div>
+      </header>
+      <main>
+        <div class="container">
+          <xsl:apply-templates/>
+        </div>
+      </main>
       <footer>
         <div class="container">
           <div class="row">

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -437,18 +437,18 @@
   </xsl:template>
 
   <xsl:template match="/">
+    <xsl:variable name="relative_path_depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/' , ''))"/>
+    <xsl:variable name="relative_path_depth_recursion">
+      <xsl:call-template name="str:repeatString">
+        <xsl:with-param name="count" select="$relative_path_depth"/>
+        <xsl:with-param name="append">../</xsl:with-param>
+      </xsl:call-template>
+    </xsl:variable>
     <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
     <xsl:value-of select='$newline'/>
     <html lang="en">
     <head>
       <title><xsl:value-of select="/guide/chapter[1]/title"/> – Gentoo Development Guide</title>
-      <xsl:variable name="relative_path_depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/' , ''))"/>
-      <xsl:variable name="relative_path_depth_recursion">
-        <xsl:call-template name="str:repeatString">
-          <xsl:with-param name="count" select="$relative_path_depth"/>
-          <xsl:with-param name="append">../</xsl:with-param>
-        </xsl:call-template>
-      </xsl:variable>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta name="description" content="The Gentoo Devmanual is a technical manual which covers topics such as writing ebuilds and eclasses, and policies that developers should be abiding by." />
       <link href="https://assets.gentoo.org/tyrian/bootstrap.min.css" rel="stylesheet" media="screen" />
@@ -508,13 +508,6 @@
               </div>
               <div class="collapse navbar-collapse navbar-main-collapse">
                 <ul class="nav navbar-nav">
-                  <xsl:variable name="relative_path_depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/' , ''))"/>
-                  <xsl:variable name="relative_path_depth_recursion">
-                    <xsl:call-template name="str:repeatString">
-                      <xsl:with-param name="count" select="$relative_path_depth"/>
-                      <xsl:with-param name="append">../</xsl:with-param>
-                    </xsl:call-template>
-                  </xsl:variable>
                   <li><a href="{concat($relative_path_depth_recursion, substring-after(substring-before(@link, '##'), '::'), 'index.html', substring-after(@link, '##'))}"><span class="fa fa-home"/>&#160; Home</a></li>
                   <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown"><xsl:value-of select="/guide/chapter[1]/title"/> <span class="caret"></span></a>
@@ -618,13 +611,6 @@
       <script src="https://assets.gentoo.org/tyrian/jquery.min.js"></script>
       <script src="https://assets.gentoo.org/tyrian/bootstrap.min.js"></script>
       <script src="https://assets.gentoo.org/lunr/lunr.min.js"></script>
-      <xsl:variable name="relative_path_depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/' , ''))"/>
-      <xsl:variable name="relative_path_depth_recursion">
-          <xsl:call-template name="str:repeatString">
-            <xsl:with-param name="count" select="$relative_path_depth"/>
-            <xsl:with-param name="append">../</xsl:with-param>
-          </xsl:call-template>
-      </xsl:variable>
       <script><xsl:text>var documentsSrc = "</xsl:text><xsl:value-of select="$relative_path_depth_recursion"/><xsl:text>documents.js"</xsl:text></script>
       <script src="{$relative_path_depth_recursion}search.js"></script>
     </body>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -469,111 +469,121 @@
     </head>
     <body>
       <header>
-        <xsl:if test="not($offline)">
-        <div class="site-title">
-          <div class="container">
-            <div class="row">
-              <div class="site-title-buttons">
-                <div class="btn-group btn-group-sm">
-                  <a href="https://get.gentoo.org/" role="button" class="btn get-gentoo"><span class="fa fa-fw fa-download"></span> <strong> Get Gentoo!</strong></a>
-                  <div class="btn-group btn-group-sm">
-                    <a class="btn gentoo-org-sites dropdown-toggle" data-toggle="dropdown" data-target="#" href="#">
-                      <span class="fa fa-fw fa-map-o"></span> <span class="hidden-xs"> gentoo.org sites </span> <span class="caret"></span>
+        <xsl:choose>
+          <xsl:when test="$offline">
+            <nav class="offline">
+              <ul>
+                <li><xsl:call-template name="findPrevious"/></li>
+                <li><xsl:call-template name="findNext"/></li>
+              </ul>
+            </nav>
+          </xsl:when>
+          <xsl:otherwise>
+            <div class="site-title">
+              <div class="container">
+                <div class="row">
+                  <div class="site-title-buttons">
+                    <div class="btn-group btn-group-sm">
+                      <a href="https://get.gentoo.org/" role="button" class="btn get-gentoo"><span class="fa fa-fw fa-download"></span> <strong> Get Gentoo!</strong></a>
+                      <div class="btn-group btn-group-sm">
+                        <a class="btn gentoo-org-sites dropdown-toggle" data-toggle="dropdown" data-target="#" href="#">
+                          <span class="fa fa-fw fa-map-o"></span> <span class="hidden-xs"> gentoo.org sites </span> <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-right">
+                          <li><a href="https://www.gentoo.org/" title="Main Gentoo website"><span class="fa fa-home fa-fw"></span> gentoo.org</a></li>
+                          <li><a href="https://wiki.gentoo.org/" title="Find and contribute documentation"><span class="fa fa-file-text-o fa-fw"></span> Wiki</a></li>
+                          <li><a href="https://bugs.gentoo.org/" title="Report issues and find common issues"><span class="fa fa-bug fa-fw"></span> Bugs</a></li>
+                          <li><a href="https://forums.gentoo.org/" title="Discuss with the community"><span class="fa fa-comments-o fa-fw"></span> Forums</a></li>
+                          <li><a href="https://packages.gentoo.org/" title="Find software for your Gentoo"><span class="fa fa-hdd-o fa-fw"></span> Packages</a></li>
+                          <li class="divider"></li>
+                          <li><a href="https://planet.gentoo.org/" title="Find out what's going on in the developer community"><span class="fa fa-rss fa-fw"></span> Planet</a></li>
+                          <li><a href="https://archives.gentoo.org/" title="Read up on past discussions"><span class="fa fa-archive fa-fw"></span> Archives</a></li>
+                          <li><a href="https://sources.gentoo.org/" title="Browse our source code"><span class="fa fa-code fa-fw"></span> Sources</a></li>
+                          <li class="divider"></li>
+                          <li><a href="https://infra-status.gentoo.org/" title="Get updates on the services provided by Gentoo"><span class="fa fa-server fa-fw"></span> Infra Status</a></li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <a href="/" title="Back to the homepage" class="site-logo">
+                      <object data="https://assets.gentoo.org/tyrian/site-logo.svg" type="image/svg+xml">
+                        <img src="https://assets.gentoo.org/tyrian/site-logo.png" alt="Gentoo Linux Logo" />
+                      </object>
                     </a>
-                    <ul class="dropdown-menu dropdown-menu-right">
-                      <li><a href="https://www.gentoo.org/" title="Main Gentoo website"><span class="fa fa-home fa-fw"></span> gentoo.org</a></li>
-                      <li><a href="https://wiki.gentoo.org/" title="Find and contribute documentation"><span class="fa fa-file-text-o fa-fw"></span> Wiki</a></li>
-                      <li><a href="https://bugs.gentoo.org/" title="Report issues and find common issues"><span class="fa fa-bug fa-fw"></span> Bugs</a></li>
-                      <li><a href="https://forums.gentoo.org/" title="Discuss with the community"><span class="fa fa-comments-o fa-fw"></span> Forums</a></li>
-                      <li><a href="https://packages.gentoo.org/" title="Find software for your Gentoo"><span class="fa fa-hdd-o fa-fw"></span> Packages</a></li>
-                      <li class="divider"></li>
-                      <li><a href="https://planet.gentoo.org/" title="Find out what's going on in the developer community"><span class="fa fa-rss fa-fw"></span> Planet</a></li>
-                      <li><a href="https://archives.gentoo.org/" title="Read up on past discussions"><span class="fa fa-archive fa-fw"></span> Archives</a></li>
-                      <li><a href="https://sources.gentoo.org/" title="Browse our source code"><span class="fa fa-code fa-fw"></span> Sources</a></li>
-                      <li class="divider"></li>
-                      <li><a href="https://infra-status.gentoo.org/" title="Get updates on the services provided by Gentoo"><span class="fa fa-server fa-fw"></span> Infra Status</a></li>
+                    <span class="site-label">Development Guide</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <nav class="tyrian-navbar" role="navigation">
+              <div class="container">
+                <div class="row">
+                  <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
+                      <span class="sr-only">Toggle navigation</span>
+                      <span class="icon-bar"></span>
+                      <span class="icon-bar"></span>
+                      <span class="icon-bar"></span>
+                    </button>
+                  </div>
+                  <div class="collapse navbar-collapse navbar-main-collapse">
+                    <ul class="nav navbar-nav">
+                      <li><a href="{concat($relative_path_depth_recursion, substring-after(substring-before(@link, '##'), '::'), 'index.html', substring-after(@link, '##'))}"><span class="fa fa-home"/>&#160; Home</a></li>
+                      <li class="dropdown">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown"><xsl:value-of select="/guide/chapter[1]/title"/> <span class="caret"></span></a>
+                        <xsl:call-template name="contentsTree">
+                          <xsl:with-param name="maxdepth" select="1"/>
+                          <xsl:with-param name="ulclass">dropdown-menu</xsl:with-param>
+                        </xsl:call-template>
+                      </li>
+                      <li><xsl:call-template name="findPrevious"/></li>
+                      <li><xsl:call-template name="findNext"/></li>
                     </ul>
                   </div>
                 </div>
               </div>
-              <div>
-                <a href="/" title="Back to the homepage" class="site-logo">
-                  <object data="https://assets.gentoo.org/tyrian/site-logo.svg" type="image/svg+xml">
-                    <img src="https://assets.gentoo.org/tyrian/site-logo.png" alt="Gentoo Linux Logo" />
-                  </object>
-                </a>
-                <span class="site-label">Development Guide</span>
+            </nav>
+            <nav class="navbar navbar-grey navbar-stick" id="devmanual-actions" role="navigation">
+              <div class="container">
+                <div class="row">
+                  <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#gw-toolbar">
+                      <span class="sr-only">Toggle navigation</span>
+                      <span class="icon-bar"></span>
+                      <span class="icon-bar"></span>
+                      <span class="icon-bar"></span>
+                    </button>
+                  </div>
+                  <div class="collapse navbar-collapse" id="gw-toolbar">
+                    <div class="input-group">
+                      <input type="search" name="search" placeholder="Search" title="Search Gentoo Developer Manual [f]" accesskey="f" id="searchInput" class="form-control" onclick="fetchDocuments()"/>
+                      <div class="input-group-btn">
+                        <input type="submit" name="fulltext" value="Search" title="Search the pages for this text" id="mw-searchButton" class="searchButton btn btn-default" onclick="search()"/>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </div>
-        <nav class="tyrian-navbar" role="navigation">
-          <div class="container">
-            <div class="row">
-              <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
-                  <span class="sr-only">Toggle navigation</span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                </button>
-              </div>
-              <div class="collapse navbar-collapse navbar-main-collapse">
-                <ul class="nav navbar-nav">
-                  <li><a href="{concat($relative_path_depth_recursion, substring-after(substring-before(@link, '##'), '::'), 'index.html', substring-after(@link, '##'))}"><span class="fa fa-home"/>&#160; Home</a></li>
-                  <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><xsl:value-of select="/guide/chapter[1]/title"/> <span class="caret"></span></a>
-                    <xsl:call-template name="contentsTree">
-                      <xsl:with-param name="maxdepth" select="1"/>
-                      <xsl:with-param name="ulclass">dropdown-menu</xsl:with-param>
-                    </xsl:call-template>
-                  </li>
-                  <li><xsl:call-template name="findPrevious"/></li>
-                  <li><xsl:call-template name="findNext"/></li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </nav>
-        <nav class="navbar navbar-grey navbar-stick" id="devmanual-actions" role="navigation">
-          <div class="container">
-            <div class="row">
-              <div class="navbar-header">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#gw-toolbar">
-                  <span class="sr-only">Toggle navigation</span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                </button>
-              </div>
-              <div class="collapse navbar-collapse" id="gw-toolbar">
-                <div class="input-group">
-                  <input type="search" name="search" placeholder="Search" title="Search Gentoo Developer Manual [f]" accesskey="f" id="searchInput" class="form-control" onclick="fetchDocuments()"/>
-                  <div class="input-group-btn">
-                    <input type="submit" name="fulltext" value="Search" title="Search the pages for this text" id="mw-searchButton" class="searchButton btn btn-default" onclick="search()"/>
+            </nav>
+            <div id="searchResults" class="modal fade" role="dialog">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">x</button>
+                    <h4 class="modal-title">Search Results</h4>
+                  </div>
+                  <div class="modal-body">
+                    <p>No results found.</p>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </nav>
-        <div id="searchResults" class="modal fade" role="dialog">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal">x</button>
-              <h4 class="modal-title">Search Results</h4>
-              </div>
-              <div class="modal-body">
-                <p>No results found.</p>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-              </div>
-            </div>
-          </div>
-        </div>
-        </xsl:if>
+          </xsl:otherwise>
+        </xsl:choose>
         <div class="container">
           <div class="row">
             <div class="col-md010">

--- a/offline.css
+++ b/offline.css
@@ -1,0 +1,19 @@
+body {
+    margin: 40px auto;
+    max-width: 650px;
+    line-height: 1.6;
+    font-size: 18px;
+    color: #454545;
+    background-color: #fafafa;
+    padding: 0 10px;
+}
+
+header, footer {
+    padding: 0.75em 1em;
+    margin: 0;
+    background-color: #e1e1e1;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    line-height: 1.2;
+}

--- a/offline.css
+++ b/offline.css
@@ -17,3 +17,29 @@ header, footer {
 h1, h2, h3, h4, h5, h6 {
     line-height: 1.2;
 }
+
+nav.offline ul, .breadcrumb {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+nav.offline li, .breadcrumb li {
+    display: inline;
+}
+
+nav.offline li+li {
+    margin-left: 1em;
+}
+
+.breadcrumb li+li:before {
+    content: " / ";
+}
+
+.fa-arrow-left:after {
+    content: "\25c4"; /* BLACK LEFT-POINTING POINTER */
+}
+
+.fa-arrow-right:after {
+    content: "\25ba"; /* BLACK RIGHT-POINTING POINTER */
+}


### PR DESCRIPTION
Pass a `fallback` flag to devbook.xsl, which disables loading of external assets and loads a simple CSS instead. This will replace the fragile patching in the `app-doc/devmanual` ebuild.

Question for reviewers, should I also remove the division containing:
> ### Questions or comments?
> Please feel free to [contact us](https://www.gentoo.org/inside-gentoo/contact/).

from the footer? The offline package currently displays it, but IMHO it looks strange in the offline version.
