### PR TITLE
Makefile: Add install target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ HTMLS := $(subst text.xml,index.html,$(XMLS))
 ECLASS_HTMLS := $(filter ./eclass-reference/%/index.html,$(ALL_FILES))
 IMAGES := $(patsubst %.svg,%.png,$(SVGS))
 
+CSS_FILES = devmanual.css offline.css
+JS_FILES = search.js documents.js
+
+prefix = /usr/local/share
+docdir = $(prefix)/doc/devmanual
+htmldir = $(docdir)
+DESTDIR =
+
 # Nonzero value disables external assets for offline browsing.
 OFFLINE = 0
 
@@ -54,6 +62,17 @@ documents.js: bin/build_search_documents.py $(XMLS)
 %.html: $$(dir $$@)text.xml devbook.xsl xsl/*.xsl $$(subst text.xml,index.html,$$(wildcard $$(dir $$@)*/text.xml))
 	xsltproc --param offline "$(OFFLINE)" devbook.xsl $< > $@
 
+install: all
+	set -e; \
+	for file in $(HTMLS) $(ECLASS_HTMLS) $(IMAGES); do \
+	  install -d "$(DESTDIR)$(htmldir)"/$${file%/*}; \
+	  install -m 644 $${file} "$(DESTDIR)$(htmldir)"/$${file}; \
+	done
+	install -m 644 $(CSS_FILES) "$(DESTDIR)$(htmldir)"/
+	if test $(OFFLINE) -eq 0; then \
+	  install -m 644 $(JS_FILES) "$(DESTDIR)$(htmldir)"/; \
+	fi
+
 validate:
 	@xmllint --noout --dtdvalid devbook.dtd $(XMLS) \
 	  && echo "xmllint validation successful"
@@ -80,4 +99,4 @@ delete-old:
 clean:
 	@rm -f $(HTMLS) $(IMAGES) _documents.js documents.js
 
-.PHONY: all prereq validate build tidy delete-old clean
+.PHONY: all prereq build install validate tidy delete-old clean

--- a/appendices/contributing/text.xml
+++ b/appendices/contributing/text.xml
@@ -26,9 +26,9 @@ If this is a problem, don't submit anything.
 
 <p>
 This document is produced using the DevBook XML build system. You can download
-a snapshot of the system as well as the relevant XML files from Subversion. You
-can also view the XML of any page by replacing <c>index.html</c> with
-<c>text.xml</c> in the URL. If you'd rather just work with plain text, that's
+a snapshot of the system as well as the relevant XML files from Git,
+see the <uri link="::appendices/contributing/#Where to find the sources">
+following section</uri>. If you'd rather just work with plain text, that's
 fine too <d/> the formatting can be easily done by someone else (meaning, us).
 </p>
 </body>


### PR DESCRIPTION
As discussed in #gentoo-qa. This will allow to much simplify the app-doc/devmanual ebuild.

On the long term, it will enable infra to install into a separate target directory.
