### PR TITLE
general-concepts/slotting: Clarify that SLOT must not be empty.

### DIFF
--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -355,8 +355,8 @@ The following variables may or must be defined by every ebuild.
 <body>
 
 <p>
-When slots are not needed, use <c>SLOT="0"</c>. Do <b>not</b> use <c>SLOT=""</c>, as
-this will disable slotting for this package.
+When slots are not needed, use <c>SLOT="0"</c>. Do <b>not</b> use
+<c>SLOT=""</c>, because the variable must not be empty.
 </p>
 
 <p>

--- a/general-concepts/slotting/text.xml
+++ b/general-concepts/slotting/text.xml
@@ -13,7 +13,8 @@ parallel. This feature is called slotting.
 
 <p>
 Most packages have no need for slotting. These packages specify <c>SLOT="0"</c>
-in the ebuilds.
+in the ebuilds. This is purely a convention; the package manager does not treat
+<c>0</c> any different from other slot values.
 </p>
 
 <note>

--- a/general-concepts/slotting/text.xml
+++ b/general-concepts/slotting/text.xml
@@ -12,11 +12,13 @@ parallel. This feature is called slotting.
 </p>
 
 <p>
-Most packages have no need for slotting. These packages specify <c>SLOT="0"</c> in
-the ebuilds. This is <b>not</b> the same as specifying an empty slot
-(<c>SLOT=""</c>) <d/> an empty
-slot means "disable slotting entirely", and should not be used.
+Most packages have no need for slotting. These packages specify <c>SLOT="0"</c>
+in the ebuilds.
 </p>
+
+<note>
+<c>SLOT</c> is a mandatory variable and must not be empty.
+</note>
 
 <p>
 Portage permits at most one instance of a package installation <e>per <c>SLOT</c>


### PR DESCRIPTION
Not sure from where the concept "an empty slot means disable slotting" originated. In any case, it is wrong, and it was not legal in any EAPI.
