### PR TITLE
Revise the navbar items

### DIFF
--- a/devbook.xsl
+++ b/devbook.xsl
@@ -677,7 +677,7 @@
       -->
       <xsl:when test="count(/guide/include) &gt; 0">
         <xsl:variable name="doc" select="/guide/include[1]/@href"/>
-        <a href="{concat($doc, 'index.html')}"><xsl:value-of select="document(concat(/guide/@self, $doc, 'text.xml'))/guide/chapter[1]/title"/> &#160;<span class="fa fa-arrow-right"/></a>
+        <a class="w-200 text-center" href="{concat($doc, 'index.html')}"><span class="truncated-text d-inline-block max-w-150 mr-1"><xsl:value-of select="document(concat(/guide/@self, $doc, 'text.xml'))/guide/chapter[1]/title"/></span><span class="fa fa-arrow-right"/></a>
       </xsl:when>
       <xsl:otherwise>
         <!-- This document's path -->
@@ -710,7 +710,7 @@
                 <xsl:with-param name="append">../</xsl:with-param>
               </xsl:call-template>
             </xsl:variable>
-            <a href="{concat($relative_path_depth_recursion, $relative_path, 'index.html')}"><xsl:value-of select="document(concat($parentItem_actual, 'text.xml'))/guide/chapter[1]/title"/> &#160;<span class="fa fa-arrow-right"/></a>
+            <a class="w-200 text-center" href="{concat($relative_path_depth_recursion, $relative_path, 'index.html')}"> <span class="truncated-text d-inline-block max-w-150 mr-1"><xsl:value-of select="document(concat($parentItem_actual, 'text.xml'))/guide/chapter[1]/title"/></span><span class="fa fa-arrow-right"/></a>
           </xsl:when>
           <xsl:otherwise>
             <!-- We need to recurse downwards; so we need to strip off a directory element off our absolute path to feed
@@ -757,7 +757,7 @@
                * Fully recurse up the node to get the last extremity
              * Otherwise list the parent -->
       <xsl:when test="/guide/@root">
-        <a href="#"><span class="fa fa-arrow-left"/>&#160; <xsl:value-of select="/guide/chapter[1]/title"/></a>
+        <a class="w-200 text-center" href="#"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-150 ml-1"><xsl:value-of select="/guide/chapter[1]/title"/></span></a>
       </xsl:when>
       <xsl:otherwise>
         <!-- This document's path -->
@@ -780,10 +780,10 @@
             </xsl:call-template>
             </xsl:variable>
             <!-- Make a relative <a> link; we need an absolute reference for the XSLT processor though... -->
-            <a href="{concat('../', substring-before($myItem_path, 'text.xml'), 'index.html')}"><span class="fa fa-arrow-left"/>&#160; <xsl:value-of select="document(concat($parentItem_path, $myItem_path))/guide/chapter[1]/title"/></a>
+            <a class="w-200 text-center" href="{concat('../', substring-before($myItem_path, 'text.xml'), 'index.html')}"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-150 ml-1"><xsl:value-of select="document(concat($parentItem_path, $myItem_path))/guide/chapter[1]/title"/></span></a>
           </xsl:when>
           <xsl:otherwise>
-            <a href="../index.html"><span class="fa fa-arrow-left"/>&#160; <xsl:value-of select="document(concat(/guide/@self, '../text.xml'))/guide/chapter[1]/title"/></a>
+            <a class="w-200 text-center" href="../index.html"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-150 ml-1"><xsl:value-of select="document(concat(/guide/@self, '../text.xml'))/guide/chapter[1]/title"/></span></a>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:otherwise>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -547,20 +547,10 @@
             <nav class="navbar navbar-grey navbar-stick" id="devmanual-actions" role="navigation">
               <div class="container">
                 <div class="row">
-                  <div class="navbar-header">
-                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#gw-toolbar">
-                      <span class="sr-only">Toggle navigation</span>
-                      <span class="icon-bar"></span>
-                      <span class="icon-bar"></span>
-                      <span class="icon-bar"></span>
-                    </button>
-                  </div>
-                  <div class="collapse navbar-collapse" id="gw-toolbar">
-                    <div class="input-group">
-                      <input type="search" name="search" placeholder="Search" title="Search Gentoo Developer Manual [f]" accesskey="f" id="searchInput" class="form-control" onclick="fetchDocuments()"/>
-                      <div class="input-group-btn">
-                        <input type="submit" name="fulltext" value="Search" title="Search the pages for this text" id="mw-searchButton" class="searchButton btn btn-default" onclick="search()"/>
-                      </div>
+                  <div class="input-group">
+                    <input type="search" name="search" placeholder="Search" title="Search Gentoo Developer Manual [f]" accesskey="f" id="searchInput" class="form-control" onclick="fetchDocuments()"/>
+                    <div class="input-group-btn">
+                      <input type="submit" name="fulltext" value="Search" title="Search the pages for this text" id="mw-searchButton" class="searchButton btn btn-default" onclick="search()"/>
                     </div>
                   </div>
                 </div>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -667,7 +667,7 @@
       -->
       <xsl:when test="count(/guide/include) &gt; 0">
         <xsl:variable name="doc" select="/guide/include[1]/@href"/>
-        <a class="w-200 text-center" href="{concat($doc, 'index.html')}"><span class="truncated-text d-inline-block max-w-150 mr-1"><xsl:value-of select="document(concat(/guide/@self, $doc, 'text.xml'))/guide/chapter[1]/title"/></span><span class="fa fa-arrow-right"/></a>
+        <a class="w-250 text-center" href="{concat($doc, 'index.html')}"><span class="truncated-text d-inline-block max-w-200 mr-2"><xsl:value-of select="document(concat(/guide/@self, $doc, 'text.xml'))/guide/chapter[1]/title"/></span><span class="fa fa-arrow-right"/></a>
       </xsl:when>
       <xsl:otherwise>
         <!-- This document's path -->
@@ -700,7 +700,7 @@
                 <xsl:with-param name="append">../</xsl:with-param>
               </xsl:call-template>
             </xsl:variable>
-            <a class="w-200 text-center" href="{concat($relative_path_depth_recursion, $relative_path, 'index.html')}"> <span class="truncated-text d-inline-block max-w-150 mr-1"><xsl:value-of select="document(concat($parentItem_actual, 'text.xml'))/guide/chapter[1]/title"/></span><span class="fa fa-arrow-right"/></a>
+            <a class="w-250 text-center" href="{concat($relative_path_depth_recursion, $relative_path, 'index.html')}"> <span class="truncated-text d-inline-block max-w-200 mr-2"><xsl:value-of select="document(concat($parentItem_actual, 'text.xml'))/guide/chapter[1]/title"/></span><span class="fa fa-arrow-right"/></a>
           </xsl:when>
           <xsl:otherwise>
             <!-- We need to recurse downwards; so we need to strip off a directory element off our absolute path to feed
@@ -747,7 +747,7 @@
                * Fully recurse up the node to get the last extremity
              * Otherwise list the parent -->
       <xsl:when test="/guide/@root">
-        <a class="w-200 text-center" href="#"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-150 ml-1"><xsl:value-of select="/guide/chapter[1]/title"/></span></a>
+        <a class="w-250 text-center" href="#"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-200 ml-2"><xsl:value-of select="/guide/chapter[1]/title"/></span></a>
       </xsl:when>
       <xsl:otherwise>
         <!-- This document's path -->
@@ -770,10 +770,10 @@
             </xsl:call-template>
             </xsl:variable>
             <!-- Make a relative <a> link; we need an absolute reference for the XSLT processor though... -->
-            <a class="w-200 text-center" href="{concat('../', substring-before($myItem_path, 'text.xml'), 'index.html')}"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-150 ml-1"><xsl:value-of select="document(concat($parentItem_path, $myItem_path))/guide/chapter[1]/title"/></span></a>
+            <a class="w-250 text-center" href="{concat('../', substring-before($myItem_path, 'text.xml'), 'index.html')}"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-200 ml-2"><xsl:value-of select="document(concat($parentItem_path, $myItem_path))/guide/chapter[1]/title"/></span></a>
           </xsl:when>
           <xsl:otherwise>
-            <a class="w-200 text-center" href="../index.html"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-150 ml-1"><xsl:value-of select="document(concat(/guide/@self, '../text.xml'))/guide/chapter[1]/title"/></span></a>
+            <a class="w-250 text-center" href="../index.html"><span class="fa fa-arrow-left"/><span class="truncated-text d-inline-block max-w-200 ml-2"><xsl:value-of select="document(concat(/guide/@self, '../text.xml'))/guide/chapter[1]/title"/></span></a>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:otherwise>

--- a/devmanual.css
+++ b/devmanual.css
@@ -40,12 +40,12 @@ pre span.Statement { color: darkred; }
     vertical-align: top;
 }
 
-.w-200 {
-    width: 200px;
+.w-250 {
+    width: 250px;
 }
 
-.max-w-150 {
-    max-width: 150px;
+.max-w-200 {
+    max-width: 200px;
 }
 
 /* compatible to Bootstrap 4 for future migration */
@@ -59,13 +59,13 @@ pre span.Statement { color: darkred; }
 }
 
 /* compatible to Bootstrap 4 for future migration */
-.mr-1 {
-    margin-right: 4px;
+.mr-2 {
+    margin-right: 8px;
 }
 
 /* compatible to Bootstrap 4 for future migration */
-.ml-1 {
-    margin-left: 4px;
+.ml-2 {
+    margin-left: 8px;
 }
 
 /* vertically center the search bar */

--- a/devmanual.css
+++ b/devmanual.css
@@ -33,4 +33,44 @@ pre span.Constant { color: black; }
 pre span.Comment { color: red; }
 pre span.Statement { color: darkred; }
 
+.truncated-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: top;
+}
+
+.w-200 {
+    width: 200px;
+}
+
+.max-w-150 {
+    max-width: 150px;
+}
+
+/* compatible to Bootstrap 4 for future migration */
+.d-inline-block {
+    display: inline-block;
+}
+
+/* compatible to Bootstrap 4 for future migration */
+.text-center {
+    text-align: center;
+}
+
+/* compatible to Bootstrap 4 for future migration */
+.mr-1 {
+    margin-right: 4px;
+}
+
+/* compatible to Bootstrap 4 for future migration */
+.ml-1 {
+    margin-left: 4px;
+}
+
+/* vertically center the search bar */
+.navbar-grey .input-group {
+    margin-top: 3px;
+}
+
 /* vim: set ts=4 tw=80 et : */


### PR DESCRIPTION
The navbar links have been shortened using css resulting in a
fixed navbar size. In addition the searchbar in the lower navbar
has been centered vertically.

Signed-off-by: Max Magorsch <arzano@gentoo.org>