### PR TITLE
Makefile, depend.xsl: Use XSLT to generate the list of dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.html
 *.png
+.depend
 documents.js
 eclass-reference/

--- a/depend.xsl
+++ b/depend.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version='1.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'
+  xmlns:exslt="http://exslt.org/common"
+  extension-element-prefixes="exslt xsl"
+  exclude-result-prefixes="exslt xsl">
+
+<xsl:import href="devbook.xsl"/>
+<xsl:output method="text"/>
+
+<xsl:template match="/">
+  <xsl:variable name="refs">
+    <!-- all descendants -->
+    <xsl:call-template name="contentsTree"/>
+    <!-- all ancestors -->
+    <xsl:call-template name="printParentDocs"/>
+    <!-- previous and next documents -->
+    <xsl:call-template name="findPrevious"/>
+    <xsl:call-template name="findNext"/>
+  </xsl:variable>
+  <xsl:variable name="self" select="/guide/@self"/>
+  <xsl:value-of select="concat($self, 'index.html:')"/>
+  <xsl:for-each select="exslt:node-set($refs)//a/@href[. != '#']">
+    <!-- At this point, the path can contain ".." components and
+         should be canonicalised, but string processing in XPath 1.0
+         sucks (no pattern matching!). It is easier to pipe the output
+         through sed instead. -->
+    <xsl:value-of select="concat(' ', $self,
+        substring-before(., 'index.html'), 'text.xml')"/>
+  </xsl:for-each>
+  <xsl:value-of select="$newline"/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -602,10 +602,7 @@
           <div class="row">
             <div class="col-md010">
               <ol class="breadcrumb">
-                <xsl:call-template name="printParentDocs">
-                  <xsl:with-param name="path" select="/guide/@self"/>
-                  <xsl:with-param name="depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/' , ''))"/>
-                </xsl:call-template>
+                <xsl:call-template name="printParentDocs"/>
               </ol>
             </div>
           </div>
@@ -805,7 +802,7 @@
   </xsl:template>
 
   <xsl:template name="printParentDocs">
-    <xsl:param name="depth"/>
+    <xsl:param name="depth" select="string-length(/guide/@self)-string-length(translate(/guide/@self, '/', ''))"/>
     <xsl:choose>
       <xsl:when test="$depth &gt; 0">
         <xsl:variable name="relative_path_depth_recursion">


### PR DESCRIPTION
Each HTML file must depend on its XML file with all its descendants (for the contents tree), all its ancestors (for breadcrumbs), and the previous and next documents (for backward and forward links).

Trying to generate the list of dependencies with make seems hopeless (especially, how would one determine the previous and next documents?). OTOH, the necessary templates already exist in devbook.xsl. Therefore, add a simple depend.xsl on top of it, which outputs a dependency list as plain text.

Closes: https://bugs.gentoo.org/710918
 