### PR TITLE
Use unicode em-dash in titles.

### DIFF
--- a/appendices/common-problems/text.xml
+++ b/appendices/common-problems/text.xml
@@ -28,7 +28,7 @@ covered here.
 </body>
 
 <subsection>
-<title>QA Notice -- USE Flag foo not in IUSE</title>
+<title>QA Notice: USE Flag foo not in IUSE</title>
 <body>
 
 <p>
@@ -42,7 +42,7 @@ See <uri link="::ebuild-writing/variables/#IUSE"/> and
 </subsection>
 
 <subsection>
-<title>QA Notice -- foo in global scope</title>
+<title>QA Notice: foo in global scope</title>
 <body>
 
 <p>
@@ -87,7 +87,7 @@ in use, there are various alternatives:
 </subsection>
 
 <subsection>
-<title>QA Notice -- foo is setXid, dynamically linked and using lazy bindings</title>
+<title>QA Notice: foo is setXid, dynamically linked and using lazy bindings</title>
 <body>
 
 <p>
@@ -111,7 +111,7 @@ for security reasons. If this message is shown, you have a couple of options:
 </subsection>
 
 <subsection>
-<title>QA Notice -- ECLASS foo inherited illegally</title>
+<title>QA Notice: ECLASS foo inherited illegally</title>
 <body>
 
 <p>

--- a/archs/alpha/text.xml
+++ b/archs/alpha/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="archs/alpha/">
 <chapter>
-<title>Arch Specific Notes -- Alpha</title>
+<title>Arch Specific Notes — Alpha</title>
 <body>
 
 <p>

--- a/archs/amd64/text.xml
+++ b/archs/amd64/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="archs/amd64/">
 <chapter>
-<title>Arch Specific Notes -- AMD64/EM64T</title>
+<title>Arch Specific Notes — AMD64/EM64T</title>
 
 <section>
 <title>Position Independent Code Issues</title>

--- a/archs/mips/text.xml
+++ b/archs/mips/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="archs/mips/">
 <chapter>
-<title>Arch Specific Notes -- MIPS</title>
+<title>Arch Specific Notes — MIPS</title>
 <body>
 
 <p>

--- a/archs/ppc/text.xml
+++ b/archs/ppc/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="archs/ppc/">
 <chapter>
-<title>Arch Specific Notes -- PPC</title>
+<title>Arch Specific Notes — PPC</title>
 <body>
 
 <p>

--- a/archs/sparc/text.xml
+++ b/archs/sparc/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="archs/sparc/">
 <chapter>
-<title>Arch Specific Notes -- SPARC</title>
+<title>Arch Specific Notes — SPARC</title>
 <body>
 
 <p>

--- a/archs/x86/text.xml
+++ b/archs/x86/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="archs/x86/">
 <chapter>
-<title>Arch Specific Notes -- x86</title>
+<title>Arch Specific Notes — x86</title>
 <body>
 
 <p>

--- a/general-concepts/overlay/text.xml
+++ b/general-concepts/overlay/text.xml
@@ -42,8 +42,8 @@ Be very careful when using eclasses in an overlay. Portage will not do cache
 updates when an overlay eclass is changed, nor will it do cache updates when a
 main Gentoo repository eclass which is used by an overlay ebuild changes. You may
 also encounter bogus 'illegal inherit' notices when working with eclasses in
-an overlay (see <uri
-link="::appendices/common-problems/#QA Notice -- ECLASS foo inherited illegally"/>).
+an overlay (see
+<uri link="::appendices/common-problems/#QA Notice: ECLASS foo inherited illegally"/>).
 To be safe, manually <c>touch</c> all relevant overlay files after updating overlay
 eclasses.
 </p>

--- a/tools-reference/bash/text.xml
+++ b/tools-reference/bash/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/bash/">
 <chapter>
-<title><c>bash</c> -- Standard Shell</title>
+<title><c>bash</c> — Standard Shell</title>
 <body>
 
 <p>

--- a/tools-reference/cat/text.xml
+++ b/tools-reference/cat/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/cat/">
 <chapter>
-<title><c>cat</c> -- File Concatenation</title>
+<title><c>cat</c> — File Concatenation</title>
 <body>
 
 <p>

--- a/tools-reference/cut/text.xml
+++ b/tools-reference/cut/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/cut/">
 <chapter>
-<title><c>cut</c> -- Column Concatenation</title>
+<title><c>cut</c> — Column Concatenation</title>
 <body>
 
 <p>

--- a/tools-reference/diff-and-patch/text.xml
+++ b/tools-reference/diff-and-patch/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/diff-and-patch/">
 <chapter>
-<title><c>diff</c> and <c>patch</c> -- File Differences</title>
+<title><c>diff</c> and <c>patch</c> — File Differences</title>
 <body>
 
 <p>

--- a/tools-reference/echo/text.xml
+++ b/tools-reference/echo/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/echo/">
 <chapter>
-<title><c>echo</c> -- Print Strings</title>
+<title><c>echo</c> — Print Strings</title>
 <body>
 
 <p>

--- a/tools-reference/ekeyword/text.xml
+++ b/tools-reference/ekeyword/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/ekeyword/">
 <chapter>
-<title><c>ekeyword</c> -- Keywording</title>
+<title><c>ekeyword</c> — Keywording</title>
 <body>
 
 <p>

--- a/tools-reference/false-and-true/text.xml
+++ b/tools-reference/false-and-true/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/false-and-true/">
 <chapter>
-<title><c>false</c> and <c>true</c> -- Generating Return Codes</title>
+<title><c>false</c> and <c>true</c> — Generating Return Codes</title>
 <body>
 
 <p>

--- a/tools-reference/find/text.xml
+++ b/tools-reference/find/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/find/">
 <chapter>
-<title><c>find</c> -- Finding Files</title>
+<title><c>find</c> — Finding Files</title>
 <body>
 
 <p>

--- a/tools-reference/grep/text.xml
+++ b/tools-reference/grep/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/grep/">
 <chapter>
-<title><c>grep</c> -- Text Filtering</title>
+<title><c>grep</c> — Text Filtering</title>
 <body>
 
 <p>

--- a/tools-reference/head-and-tail/text.xml
+++ b/tools-reference/head-and-tail/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/head-and-tail/">
 <chapter>
-<title><c>head</c> and <c>tail</c> -- Line Extraction</title>
+<title><c>head</c> and <c>tail</c> — Line Extraction</title>
 <body>
 
 <p>

--- a/tools-reference/sed/text.xml
+++ b/tools-reference/sed/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/sed/">
 <chapter>
-<title>sed -- Stream Editor</title>
+<title>sed — Stream Editor</title>
 <body>
 
 <p>

--- a/tools-reference/sort/text.xml
+++ b/tools-reference/sort/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/sort/">
 <chapter>
-<title>sort -- Sorting Text</title>
+<title>sort — Sorting Text</title>
 <body>
 
 <p>

--- a/tools-reference/tr/text.xml
+++ b/tools-reference/tr/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/tr/">
 <chapter>
-<title>tr -- Character Translation</title>
+<title>tr — Character Translation</title>
 <body>
 
 <p>

--- a/tools-reference/uniq/text.xml
+++ b/tools-reference/uniq/text.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <guide self="tools-reference/uniq/">
 <chapter>
-<title>uniq -- Filtering Duplicates</title>
+<title>uniq — Filtering Duplicates</title>
 <body>
 
 <p>


### PR DESCRIPTION
Replace -- in titles by em-dashes throughout, except for QA notices in appendices/common-problems where it is replaced by a colon (which is what the actual QA notices have).
