### PR TITLE
ebuild-writing/misc-files/metadata: Update description tag

### DIFF
--- a/ebuild-writing/misc-files/metadata/text.xml
+++ b/ebuild-writing/misc-files/metadata/text.xml
@@ -223,7 +223,7 @@ metadata.xml:
 <tr>
   <ti><c>&lt;bugs-to&gt;</c></ti>
   <ti>
-    Should contain a place where bugs can be filed, a URL or an e-mail address prefixed
+    Should contain a place where bugs can be filed, an URL or an e-mail address prefixed
     with <c>mailto:</c>. May appear at most once.
   </ti>
 </tr>

--- a/ebuild-writing/misc-files/metadata/text.xml
+++ b/ebuild-writing/misc-files/metadata/text.xml
@@ -104,8 +104,8 @@ metadata.xml:
 <tr>
   <ti><c>&lt;description&gt;</c></ti>
   <ti>
-    The description tag contains a description of the maintainership, or for 
-    example a remark that someone interested can take over the maintainership. 
+    The description tag adds important information about the maintainer such as "Tests driver on xyz printer" or "Upstream. Please CC."
+    This tag should not be used to mark that someone is allowed to help maintain the package. 
     It is optional.
   </ti>
 </tr>


### PR DESCRIPTION
Description tag should be used to describe important information about
this maintainer. Not to explain that this maintainer does not want to
maintain the package, or allows others to help.