### PR TITLE
Improve the usage of the term "ebuild phase functions"

### DIFF
--- a/ebuild-writing/functions/text.xml
+++ b/ebuild-writing/functions/text.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 <guide self="ebuild-writing/functions/">
 <chapter>
-<title>Ebuild Functions</title>
+<title>Ebuild Phase Functions</title>
 
 <body>
 <p>
-When installing packages from source, the function call order is
+When installing packages from source, the phase function call order is
 <c>pkg_pretend</c>, <c>pkg_setup</c>,
 <c>src_unpack</c>, <c>src_prepare</c>, <c>src_configure</c>, <c>src_compile</c>,
 <c>src_test</c> (optional, <c>FEATURES="test"</c>),
 <c>src_install</c>, <c>pkg_preinst</c>, <c>pkg_postinst</c>. When installing packages
-from a binary, the function call order is <c>pkg_pretend</c>,
+from a binary, the phase function call order is <c>pkg_pretend</c>,
 <c>pkg_setup</c>, <c>pkg_preinst</c>, <c>pkg_postinst</c>.
 As some phases haven't been introduced from the beginning, you can have a look at
 <uri link="::ebuild-writing/eapi"/> for an overview, what have been introduced in which EAPI.
 </p>
 
-<figure short="How the ebuild functions are processed" link="diagram.png"/>
+<figure short="How the ebuild phase functions are processed" link="diagram.png"/>
 
 <p>
 The <c>pkg_pretend</c> function is to be used for performing various
@@ -43,8 +43,9 @@ location, and Portage records digests of the files installed.
 </p>
 
 <p>
-When testing or debugging, you can instruct Portage to execute a specific function
-from an ebuild by using the <c>ebuild</c> command, see the <c>ebuild(1)</c> manual
+When testing or debugging, you can instruct Portage to execute a
+specific phase function of an ebuild by using the <c>ebuild</c>
+command, see the <c>ebuild(1)</c> manual
 page for further information.
 </p>
 

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -643,7 +643,7 @@ domacosapp() {
 <body>
 
 <p>
-An eclass may provide default implementations for any of the standard ebuild
+An eclass may provide default implementations for any of the ebuild phase
 functions (<c>src_unpack</c>, <c>pkg_postinst</c> etc). This can be done either as a
 simple function definition (which is not multiple eclass friendly) or using
 <c>EXPORT_FUNCTIONS</c>. Functions given to <c>EXPORT_FUNCTIONS</c> are implemented
@@ -651,7 +651,7 @@ as normal, but have their name prefixed with <c>${ECLASS}_</c>.
 </p>
 
 <important>
-Only 'standard' functions should be specified in <c>EXPORT_FUNCTIONS</c>.
+Only the ebuild phase functions may be specified in <c>EXPORT_FUNCTIONS</c>.
 </important>
 
 <note><c>EXPORT_FUNCTIONS</c> is a function, <e>not</e> a variable.</note>


### PR DESCRIPTION
When the text specifically refers to phase functions, be more verbose about it. Ebuilds can define other functions that are internal. Eclasses also define functions. Using the term "phase functions" should help clarify the ambiguity.
