### PR TITLE
arch/ppc: Fix project IRC channel name

### DIFF
--- a/archs/ppc/text.xml
+++ b/archs/ppc/text.xml
@@ -71,7 +71,7 @@ The PowerPC team can be reached by:
 
 <ul>
   <li>
-    Via the <c>#gentoo-ppc</c> IRC channel on freenode
+    Via the <c>#gentoo-powerpc</c> IRC channel on freenode
   </li>
   <li>
     Via email to <c>ppc@gentoo.org</c>


### PR DESCRIPTION
Gentoo's PPC and PPC64 projects share the
channel #gentoo-powerpc, not #gentoo-ppc.

Signed-off-by: Sam James <sam@gentoo.org>