### PR TITLE
ebuild-writing/common-mistakes: Drop note on Header/Id line

### DIFF
--- a/ebuild-writing/common-mistakes/text.xml
+++ b/ebuild-writing/common-mistakes/text.xml
@@ -184,13 +184,6 @@ The first two lines <e>must</e> look like this:
 # Distributed under the terms of the GNU General Public License v2
 </pre>
 
-<note>
-The header previously included a third line with a CVS <c>&#36;Id&#36;</c>
-or <c>&#36;Header&#36;</c> keyword. That line was abolished after conversion
-to Git by <uri link="https://bugs.gentoo.org/611234">decision of the Gentoo
-Council on 28 February 2017</uri> and <e>must not</e> be added any more.
-</note>
-
 </body>
 </subsection>
 <subsection>


### PR DESCRIPTION
This is no longer a common mistake. Exactly the same note is still present in ebuild-writing/file-format.
