### PR TITLE
general-concepts/licenses: LICENSE should include build scripts

### DIFF
--- a/general-concepts/licenses/text.xml
+++ b/general-concepts/licenses/text.xml
@@ -11,10 +11,16 @@ match files existing in the repository's <c>licenses/</c> directory.
 </p>
 
 <p>
-The value of this variable should include all licenses pertaining
-to the files installed by the package. If some parts of the package
-are installed only conditionally, or their license depends on the USE
-flag combination, you can use USE conditionals in <c>LICENSE</c>:
+The value of this variable should include all licenses pertaining to the
+"corresponding source" of the files installed by the package. This includes
+all their source code, but also all scripts used to control compilation and
+installation.
+</p>
+
+<p>
+If some parts of the package are installed only conditionally, or their
+license depends on the USE flag combination, you can use USE conditionals
+in <c>LICENSE</c>:
 </p>
 
 <codesample lang="ebuild">
@@ -22,10 +28,8 @@ LICENSE="LGPL-2.1+ tools? ( GPL-2+ )"
 </codesample>
 
 <p>
-If the package sources include additional files that are not installed,
-their license should not be listed. However, if those files are used
-at build time, then the license must not impose any restrictions that
-could prevent users from building the software.
+If the package sources include additional files that are neither installed
+nor used at build time, their license should not be listed.
 </p>
 
 <p>


### PR DESCRIPTION
By the FSF's definition (see for example GPL-3):
"The 'Corresponding Source' for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities."

It makes much sense to apply this as a general definition. Applying it only to GPL licensed packages would mean:
- We would need another case distinction, making the rules for LICENSE even more complicated.
- As an example, consider a MIT licensed package with a CDDL licensed (i.e., GPL incompatible) build script: If that package was a library, then it couldn't be linked against a GPL licensed package, whereas a LICENSE variable listing only MIT would falsely indicate that it could.

@gentoo/licenses