### PR TITLE
keywording: Clarify self-testing on amd64/x86

### DIFF
--- a/keywording/text.xml
+++ b/keywording/text.xml
@@ -299,10 +299,9 @@ Vulnerability Treatment Policy</uri>
 <body>
 
 <p>
-AMD64, X86: If you are the maintainer of a package that currently has open bugs
-for amd64 or x86 stabilization and own the respectively amd64 or x86 hardware,
-you can do your own testing and keywording of your packages; as long as it is
-not a core system set dependency.
+AMD64, X86: If you are the maintainer of a package and own the respective amd64
+or x86 hardware, you can do your own testing (stabilization and keywording) of
+your packages; as long as it is not a core system set dependency.
 </p>
 
 <p>

--- a/keywording/text.xml
+++ b/keywording/text.xml
@@ -301,7 +301,10 @@ Vulnerability Treatment Policy</uri>
 <p>
 AMD64, X86: If you are the maintainer of a package and own the respective amd64
 or x86 hardware, you can do your own testing (stabilization and keywording) of
-your packages; as long as it is not a core system set dependency.
+your packages; as long as it is not a core system set dependency. Note that
+it is acceptable to test x86 using a
+<uri link="https://wiki.gentoo.org/wiki/Project:AMD64/32-bit_Chroot_Guide">
+specialized environment on amd64</uri>.
 </p>
 
 <p>


### PR DESCRIPTION
Some confusion occurred about whether this
was just for keywording or not, so I've
changed the phrasing.

I've also removed the requirement for a bug;
this isn't required in practice and adds
unnecessary overhead.

Signed-off-by: Sam James <sam@gentoo.org>