### PR TITLE
*/*: Use modern example of a prefix arch/keyword

### DIFF
--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -45,7 +45,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha ~amd64 ~x86 ~x86-fbsd"
+KEYWORDS="alpha ~amd64 ~x86 ~x64-macos"
 
 RDEPEND="sys-libs/ncurses:0=
 	&gt;=sys-libs/readline:0="

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -503,7 +503,7 @@ You need not assign the IUSE variable in your ebuild if it is empty.
 </note>
 
 <p>
-Arch USE flags (<c>sparc</c>, <c>mips</c>, <c>x86-fbsd</c> and so on) should not be
+Arch USE flags (<c>sparc</c>, <c>mips</c>, <c>x64-macos</c> and so on) should not be
 listed.
 </p>
 

--- a/general-concepts/virtuals/text.xml
+++ b/general-concepts/virtuals/text.xml
@@ -28,7 +28,7 @@ EAPI=7
 
 DESCRIPTION="Virtual for C++ tr1 &lt;type_traits&gt;"
 SLOT="0"
-KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 sparc x86 ~x86-fbsd"
+KEYWORDS="alpha amd64 arm hppa ia64 ~mips ppc ppc64 ~s390 sparc x86 ~x64-macos"
 
 RDEPEND="|| ( &gt;=sys-devel/gcc-4.1 dev-libs/boost )"
 </codesample>

--- a/keywording/text.xml
+++ b/keywording/text.xml
@@ -14,7 +14,7 @@ distinction is important.
 <p>
 Most ebuilds specify a <c>KEYWORDS</c> variable. This variable is used to
 indicate the suitability and stability of both the package and the ebuild on
-each given arch (<c>sparc</c>, <c>ppc</c>, <c>x86-obsd</c>, ...).
+each given arch (<c>sparc</c>, <c>ppc</c>, <c>x64-macos</c>, ...).
 </p>
 
 <note>


### PR DESCRIPTION
    */*: Use modern example of a prefix arch/keyword

    Gentoo/OpenBSD and Gentoo/FreeBSD are gone, but
    we still have Prefix which has some arches
    like ~x64-macos, so let's use that to keep
    the same level of variety.
