### PR TITLE
ebuild-writing/functions/src_unpack/vcs-sources: remove bzr.eclass

### DIFF
--- a/ebuild-writing/functions/src_unpack/vcs-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/vcs-sources/text.xml
@@ -13,7 +13,6 @@ variables.
 </p>
 
 <ul>
-  <li><uri link="::eclass-reference/bzr.eclass/"/></li>
   <li><uri link="::eclass-reference/cvs.eclass/"/></li>
   <li><uri link="::eclass-reference/darcs.eclass/"/></li>
   <li><uri link="::eclass-reference/git-r3.eclass/"/></li>


### PR DESCRIPTION
 - bzr.eclass has been removed from ::gentoo repository by
   https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=79a3d7f7c3ca5f1af64f0d5e60cd490ca62f3c05
   so the link isn't functional.