### PR TITLE
general-concepts/dependencies: sort dependencies, add revision notice

### DIFF
--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -431,7 +431,9 @@ This can be nested:
 
 <codesample lang="ebuild">
 DEPEND="!build? (
+	&gt;=sys-libs/ncurses-5.2-r2
 	gcj? (
+		&gt;=media-libs/libart_lgpl-2.1
 		gtk? (
 			x11-libs/libXt
 			x11-libs/libX11
@@ -441,9 +443,7 @@ DEPEND="!build? (
 			&gt;=x11-libs/gtk+-2.2
 			x11-libs/pango
 		)
-		&gt;=media-libs/libart_lgpl-2.1
 	)
-	&gt;=sys-libs/ncurses-5.2-r2
 	nls? ( sys-devel/gettext )
 )"
 </codesample>

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -17,6 +17,12 @@ checking for changes. Some projects may have different policies <d/> consult
 them if you're not sure.
 </p>
 
+<p>
+Please also see the following section on
+<uri link="::general-concepts/ebuild-revisions"/>
+for how dependencies and revisions interact.
+</p>
+
 </body>
 
 <section>

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -9,6 +9,14 @@ Automatic dependency resolution is one of the most useful features
 provided by <c>emerge</c>.
 </p>
 
+<p>
+You are encouraged to sort dependencies alphabetically, with unconditional
+dependencies grouped together, then all conditional dependencies. There is an
+exception: you may sort dependencies as per upstream listings if it eases
+checking for changes. Some projects may have different policies <d/> consult
+them if you're not sure.
+</p>
+
 </body>
 
 <section>


### PR DESCRIPTION
- Add note regarding sorting dependencies
- Sort dependencies in example
- Include a notice to consider the Ebuild Revisions section