### PR TITLE
*/*: miscellaneous fixes

### DIFF
--- a/ebuild-writing/error-handling/text.xml
+++ b/ebuild-writing/error-handling/text.xml
@@ -57,9 +57,10 @@ Sometimes displaying additional error information beforehand can be useful. Use
 <c>eerror</c> to do this. See <uri link="::ebuild-writing/messages"/>.
 </p>
 
-<p>
-It's best to use <c>|| die</c> too often than too little.
-</p>
+<note>
+You should use <c>die</c> on almost all external commands in ebuilds.
+</note>
+
 </body>
 </section>
 

--- a/tools-reference/bash/text.xml
+++ b/tools-reference/bash/text.xml
@@ -120,6 +120,14 @@ all new code.
 </important>
 
 <p>
+POSIX compliance is not a concern for ebuilds, as their interpreter is
+guaranteed to be GNU Bash. POSIX style tests have different semantics
+and using the common forms of tests adheres to the principle of least surprise.
+Most developers will be used to Bash test semantics and behaviour and
+deviating from this in ebuilds may be confusing.
+</p>
+
+<p>
 This is because <c>[[ ]]</c> is a bash syntax construct, whereas <c>[ ]</c> is a
 program which happens to be implemented as an internal <d/> as such, cleaner
 syntax is possible with the former. For a simple illustration, consider:

--- a/tools-reference/text.xml
+++ b/tools-reference/text.xml
@@ -9,6 +9,12 @@ This section provides an overview of various useful standard Unix and Gentoo
 tools and utilities that may be used within ebuilds or when working with
 ebuilds.
 </p>
+
+<p>
+Please keep in mind the need for
+<uri link="::ebuild-writing/error-handling/#The die Function">error handling</uri>
+when using these tools in ebuilds.
+</p>
 </body>
 
 <section>


### PR DESCRIPTION
Please let me know if you'd prefer I split this up.

- bash: make clear that ```[[ ]]``` tests are preferred when we reference them earlier on (and why)
- diff-and-patch: fix man page notation
- error-handling: mention the need to || die with external commands
- tools-reference: refer to aforementioned die