### PR TITLE
eclass-writing: Add more eclass doc tags, information on etiquette

### DIFF
--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -90,6 +90,17 @@ Committing a broken eclass can kill huge numbers of packages. Since
 A simple way to verify syntax is <c>bash -n foo.eclass</c>.
 </p>
 
+<note>
+Given that updating an eclass will invalidate the cache of all consumer ebuilds,
+it is good etiquette to ping other developers in e.g. <c>#gentoo-dev</c> on IRC
+or informally determine if there are other similar changes (mainly documentation)
+which should be pushed at the same time in order to avoid unnecessary cache
+regeneration within a few hours or days of each other.
+
+The same applies to your own work <d/> please prepare all of your commits and
+batch push them at once where possible.
+</note>
+
 </body>
 </section>
 

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -568,12 +568,8 @@ using the following tags:
   <th>description</th>
 </tr>
 <tr>
-  <ti>
-    <c>@VARIABLE:</c>
-  </ti>
-  <ti>
-    NO
-  </ti>
+  <ti><c>@VARIABLE:</c></ti>
+  <ti>NO</ti>
   <ti>
     Name of the function-specific variable to which the documentation applies.
   </ti>
@@ -584,61 +580,53 @@ using the following tags:
   </ti>
 </tr>
 <tr>
-  <ti>
-    <c>@DEFAULT_UNSET</c>
-  </ti>
-  <ti>
-    YES
-  </ti>
-  <ti>
-    <d/>
-  </ti>
+  <ti><c>@USER_VARIABLE</c></ti>
+   <ti>YES</ti>
+   <ti><d/></ti>
+   <ti>
+     This tag describes whether the variable is unsuitable for use in ebuilds,
+     i.e. if it is solely for user consumption via e.g. make.conf or a similar
+     mechanism.
+   </ti>
+</tr>
+<tr>
+  <ti><c>@DEFAULT_UNSET</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
     Indicates that this variable is unset by default if not set by the
     developer.
   </ti>
 </tr>
 <tr>
-  <ti>
-    <c>@INTERNAL</c>
-  </ti>
-  <ti>
-    YES
-  </ti>
-  <ti>
-    <d/>
-  </ti>
-  <ti>
-    Indicates that the variable is internal to the eclass function.
-  </ti>
+  <ti><c>@INCLUDES_EPREFIX</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
+  <ti>Indicates that the variable is a path which has ${EPREFIX} prepended.</ti>
 </tr>
 <tr>
-  <ti>
-    <c>@REQUIRED</c>
-  </ti>
-  <ti>
-    YES
-  </ti>
-  <ti>
-    <d/>
-  </ti>
-  <ti>
-    Indicates that this variable must be set by the developer.
-  </ti>
+  <ti><c>@INTERNAL</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
+  <ti>Indicates that the variable is internal to the eclass function.</ti>
 </tr>
 <tr>
-  <ti>
-    <c>@DESCRIPTION:</c>
-  </ti>
-  <ti>
-    NO
-  </ti>
-  <ti>
-    Multiline freetext.
-  </ti>
-  <ti>
-    Long description for the function variable.
-  </ti>
+  <ti><c>@REQUIRED</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
+  <ti>Indicates that this variable must be set by the developer.</ti>
+</tr>
+<tr>
+  <ti><c>@DEPRECATED</c></ti>
+  <ti>YES</ti>
+  <ti>Optionally, the name of any replacement variable.</ti>
+  <ti>Declares that this variable should no longer be used in ebuilds.</ti>
+</tr>
+<tr>
+  <ti><c>@DESCRIPTION:</c></ti>
+  <ti>NO</ti>
+  <ti>Multiline freetext.</ti>
+  <ti>Long description for the function variable.</ti>
 </tr>
 </table>
 

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -658,10 +658,10 @@ domacosapp() {
 
 <p>
 An eclass may provide default implementations for any of the ebuild phase
-functions (<c>src_unpack</c>, <c>pkg_postinst</c> etc). This can be done either as a
+functions (<c>src_unpack</c>, <c>pkg_postinst</c>, etc). This can be done either as a
 simple function definition (which is not multiple eclass friendly) or using
 <c>EXPORT_FUNCTIONS</c>. Functions given to <c>EXPORT_FUNCTIONS</c> are implemented
-as normal, but have their name prefixed with <c>${ECLASS}_</c>.
+as normal, but have their name prefixed ("namespaced") with <c>${ECLASS}_</c>.
 </p>
 
 <important>

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -508,19 +508,28 @@ documentation are:
   </ti>
 </tr>
 <tr>
+  <ti><c>@INCLUDES_EPREFIX</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
-    <c>@INTERNAL</c>
+    Indicates whether the function returns a path with ${EPREFIX} prepended
+    to it.
   </ti>
-  <ti>
-    YES
-  </ti>
-  <ti>
-    <d/>
-  </ti>
+</tr>
+<tr>
+  <ti><c>@INTERNAL</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
     Indicates that the function is internal to the eclass and should
     not be called from outside.
   </ti>
+</tr>
+<tr>
+  <ti><c>@DEPRECATED</c></ti>
+  <ti>YES</ti>
+  <ti>Optionally, the name of a replacement function.</ti>
+  <ti>Declares that this function should no longer be used in ebuilds.</ti>
 </tr>
 <tr>
   <ti>

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -151,6 +151,14 @@ multiline freetext, the <c>@CODE</c> tag should be used when necessary
 to create unformatted code chunks (such as example code) by placing
 the tag at the beginning and the end.
 </p>
+
+<p>
+Note that <c>pkgcheck</c> can check for issues in eclass documentation.
+You could run e.g. <c>pkgcheck scan -s eclass</c> to check for issues
+in the tree or <c>pkgcheck scan --commits</c> to check for issues
+in your staged git commits.
+</p>
+
 </body>
 </section>
 

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -350,61 +350,74 @@ variables are as follows:
   </ti>
 </tr>
 <tr>
+  <ti><c>@PRE_INHERIT</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
-    <c>@DEFAULT_UNSET</c>
+    This tag describes whether the variable must be defined before
+    the eclass is inherited. This is important if any e.g. dependencies
+    are modified in global scope at the point of sourcing.
   </ti>
+</tr>
+<tr>
+  <ti><c>@USER_VARIABLE</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
-    YES
+    This tag describes whether the variable is unsuitable for use in ebuilds,
+    i.e. if it is solely for user consumption via e.g. make.conf or a similar
+    mechanism.
   </ti>
+</tr>
+<tr>
+  <ti><c>@OUTPUT_VARIABLE</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
-    <d/>
+    This tag indicates that the variable's value (which will be set by the eclass)
+    should be read within an ebuild.
   </ti>
+</tr>
+<tr>
+  <ti><c>@DEFAULT_UNSET</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
     Indicates that this variable is unset by default if not set by the
     developer.
   </ti>
 </tr>
 <tr>
+  <ti><c>@INCLUDES_EPREFIX</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
   <ti>
-    <c>@INTERNAL</c>
-  </ti>
-  <ti>
-    YES
-  </ti>
-  <ti>
-    <d/>
-  </ti>
-  <ti>
-    Indicates that the variable is internal to the eclass.
+    Indicates that the variable is a path which has ${EPREFIX} prepended to it.
   </ti>
 </tr>
 <tr>
-  <ti>
-    <c>@REQUIRED</c>
-  </ti>
-  <ti>
-    YES
-  </ti>
-  <ti>
-    <d/>
-  </ti>
-  <ti>
-    Indicates that this variable must be set by the developer.
-  </ti>
+  <ti><c>@INTERNAL</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
+  <ti>Indicates that the variable is internal to the eclass.</ti>
 </tr>
 <tr>
-  <ti>
-    <c>@DESCRIPTION:</c>
-  </ti>
-  <ti>
-    NO
-  </ti>
-  <ti>
-    Multiline freetext.
-  </ti>
-  <ti>
-    Long description for the eclass variable.
-  </ti>
+  <ti><c>@REQUIRED</c></ti>
+  <ti>YES</ti>
+  <ti><d/></ti>
+  <ti>Indicates that this variable must be set by the developer.</ti>
+</tr>
+<tr>
+  <ti><c>@DEPRECATED</c></ti>
+  <ti>YES</ti>
+  <ti>Optionally, the name of any replacement variable.</ti>
+  <ti>Declares that this variable should no longer be used in ebuilds.</ti>
+</tr>
+<tr>
+  <ti><c>@DESCRIPTION:</c></ti>
+  <ti>NO</ti>
+  <ti>Multiline freetext.</ti>
+  <ti>Long description for the eclass variable.</ti>
 </tr>
 </table>
 

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -698,7 +698,7 @@ Then an ebuild could do this:
 </p>
 
 <codesample lang="ebuild">
-inherit fnord.eclass
+inherit fnord
 
 src_compile() {
 	do_pre_stuff || die

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -130,6 +130,11 @@ adhere to the following process:</p>
   </li>
 </ol>
 
+<note>
+Before considering removal, please mark the eclass as <c># @DEPRECATED</c>
+to ensure consumers are warned if they are still using the eclass. Do this
+for a period before removing the eclass.
+</note>
 
 </body>
 </section>

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -28,7 +28,7 @@ Roughly speaking, there are three kinds of eclass:
   <li>
     Those which provide common functions which are used by many ebuilds (for
     example, <c>autotools</c>, <c>bash-completion-r1</c>, <c>flag-o-matic</c>,
-    <c>toolchain-funcs</c>
+    <c>toolchain-funcs</c>)
   </li>
   <li>
     Those which provide a basic build system for many similar packages (for

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -70,7 +70,10 @@ package, and thus does not typically require changes to be emailed for review.
 
 <p>
 When removing a function or changing the API of an eclass, make sure that
-it doesn't break any ebuilds in the Gentoo repository.
+it doesn't break any ebuilds in the Gentoo repository. Optionally, you may wish
+to do a survey of some (official) overlays like <c>::guru</c>, <c>::musl</c>, or
+<c>::science</c> in order to better understand how it is currently used and
+<d/> where possible <d/> avoid breakage by pinging the maintainers directly.
 </p>
 
 <p>


### PR DESCRIPTION
- Add more eclass doc tags. Note that I wasn't sure if they were left out for a reason or just nobody got to it yet. Please consider this part more of a draft. 

Specifically:
```
* @PRE_INHERIT
* @USER_VARIABLE
* @OUTPUT_VARIABLE
* @INCLUDES_EPREFIX
* @DEPRECATED
```

- Mention etiquette when modifying eclasses

- Various extra eclass writing information/tips/terminology