### PR TITLE
general-concepts/use-flags: Fix indentation in code example

### DIFF
--- a/general-concepts/use-flags/text.xml
+++ b/general-concepts/use-flags/text.xml
@@ -305,7 +305,7 @@ src_compile() {
 	elif use ssl &amp;&amp; ! use gnutls ; then
 		myconf="${myconf} --enable-ssl --with-ssl=openssl"
 	else
-	myconf="${myconf} --disable-ssl"
+		myconf="${myconf} --disable-ssl"
 	fi
 
 	econf \


### PR DESCRIPTION
Fix indentation [in code example](https://devmanual.gentoo.org/general-concepts/use-flags/#conflicting-use-flags).