### PR TITLE
ebuild-writing/misc-files/patches: discourage commenting out lines

### DIFF
--- a/ebuild-writing/misc-files/patches/text.xml
+++ b/ebuild-writing/misc-files/patches/text.xml
@@ -96,8 +96,8 @@ from the <c>vim</c> patch tarball:
 <pre>
 # Detect Gentoo apache files properly. Gentoo bug 83565.
 
---- runtime/filetype.vim.orig   2005-03-25 01:44:12.000000000 +0000
-+++ runtime/filetype.vim        2005-03-25 01:45:15.000000000 +0000
+--- a/runtime/filetype.vim
++++ b/runtime/filetype.vim
 @@ -93,6 +93,9 @@
  " Gentoo apache config file locations (Gentoo bug #76713)
  au BufNewFile,BufRead /etc/apache2/conf/*/* setf apache

--- a/ebuild-writing/misc-files/patches/text.xml
+++ b/ebuild-writing/misc-files/patches/text.xml
@@ -294,6 +294,14 @@ files automatically. Alternatively, you can specify the <c>-E</c> option with
 </p>
 
 <p>
+Removed lines should not appear in the patch because they are commented <d/> just
+remove them entirely. Patches show removed lines by prefixing them with
+a <c>-</c>, so no information is lost by simply deleting lines rather than
+commenting them out (which adds noise). This makes the patch shorter and
+more readable.
+</p>
+
+<p>
 The following function (for your interactive shell, not for the ebuild) will
 help deleting these things:
 </p>


### PR DESCRIPTION
We shouldn't add comments (#) within patch changes to source code (etc) because
it's unnecessary noise. Comments *at the top* of the patch are, of course, welcoome.