### PR TITLE
ebuild-writing/common-mistakes: add 'Calling pkg-config directly'

### DIFF
--- a/ebuild-writing/common-mistakes/text.xml
+++ b/ebuild-writing/common-mistakes/text.xml
@@ -477,8 +477,29 @@ at least when the ebuild hits the stable branch.
 </p>
 </body>
 </subsection>
-</section>
 
+<subsection>
+<title>Calling pkg-config directly</title>
+<body>
+
+<p>
+You should not call <c>pkg-config</c> directly in ebuilds because this is
+problematic for e.g. cross-compiling. The correct helper respects
+<c>${PKG_CONFIG}</c>. Instead, use <c>tc-getPKG_CONFIG</c> from
+<c>toolchain-funcs.eclass</c>, e.g.
+</p>
+
+<codesample lang="ebuild">
+sed -i -e 's/-lncurses/$($(tc-getPKG_CONFIG) --libs ncurses)/' || die
+</codesample>
+
+<p>
+Don't then forget to add <c>virtual/pkgconfig</c> to BDEPEND!
+</p>
+
+</body>
+</subsection>
+</section>
 
 <section>
 <title>Common Ebuild Submission Mistakes</title>


### PR DESCRIPTION
Quite a lot of ebuilds do this. We should instead use the tc-getPKG_CONFIG
helper from toolchain-funcs.eclass which respects ${PKG_CONFIG} - useful
for e.g. cross-compiling.

Signed-off-by: Sam James <sam@gentoo.org>