### PR TITLE
ebuild-writing/functions/src_configure/configuring: fix whitespace in $(use_enable)

### DIFF
--- a/ebuild-writing/functions/src_configure/configuring/text.xml
+++ b/ebuild-writing/functions/src_configure/configuring/text.xml
@@ -32,16 +32,16 @@ where appropriate, be used to generate these switches.
 src_configure() {
 	# We have optional perl, python and ruby support
 	econf \
-		$(use_enable perl ) \
-		$(use_enable python ) \
-		$(use_enable ruby )
+		$(use_enable perl) \
+		$(use_enable python) \
+		$(use_enable ruby)
 }
 
 src_configure() {
 	# Our package optional IPv6 support which uses --with rather than
 	# --enable / --disable
 
-	econf $(use_with ipv6 )
+	econf $(use_with ipv6)
 }
 </codesample>
 
@@ -56,15 +56,15 @@ argument forms:
 src_configure() {
 	# Our package has optional perl, python and ruby support
 	econf \
-		$(use_enable perl perlinterp ) \
-		$(use_enable python pythoninterp ) \
-		$(use_enable ruby rubyinterp )
+		$(use_enable perl perlinterp) \
+		$(use_enable python pythoninterp) \
+		$(use_enable ruby rubyinterp)
 
 	# ...
 }
 
 src_configure() {
-	econf $(use_with X x11 )
+	econf $(use_with X x11)
 }
 </codesample>
 


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>