### PR TITLE
general-concepts/ebuild-revisions: update revision bump examples

### DIFF
--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -67,6 +67,7 @@ of thumb could be used as a guideline:
   <li>adding a patch to fix a runtime issue,</li>
   <li>installing additional files that could be useful to the user,</li>
   <li>adding a missing runtime dependency to one of the existing blocks,</li>
+  <li>adding a binding subslot operator (:=) to a dependency,</li>
   <li>
     adding a missing build-time dependency that contributed to
     a successfully yet incorrect build (e.g. missing some feature),

--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -68,6 +68,7 @@ of thumb could be used as a guideline:
   <li>installing additional files that could be useful to the user,</li>
   <li>adding a missing runtime dependency to one of the existing blocks,</li>
   <li>adding a binding subslot operator (:=) to a dependency,</li>
+  <li>updating a dependency with default on/off USE flags,</li>
   <li>
     adding a missing build-time dependency that contributed to
     a successfully yet incorrect build (e.g. missing some feature),


### PR DESCRIPTION
- A revision bump is needed for a rebuild to occur when e.g. ABI is broken.

Without doing this, we're relying on Portage's preserve-libs feature which
does not have to be enabled and is not specified by PMS.

- Without revision bumping in cases where we change USE dep defaults in a
dependency, the package manager will refuse an upgrade because newer
versions of the dependency will not satisfy the requirements
in the package.