### PR TITLE
keywording: remove mentioning of STABLEREQ bugs.g.o keywords

### DIFF
--- a/keywording/text.xml
+++ b/keywording/text.xml
@@ -402,7 +402,7 @@ keyword, so packages are not to be marked stable for one of these architectures.
 If you maintain an architecture-independent package (data files, icons, pure
 Python, ...), then you may request that your package be stabilized on all arches
 at once. To do this <d/> when you are filing the stabilization bug <d/> please
-add the keyword <c>ALLARCHES</c> in addition to <c>STABLEREQ</c> and CC the
+add the keyword <c>ALLARCHES</c> and CC the
 arches that you would like to stabilize.
 </p>
 


### PR DESCRIPTION
This keyword is no longer used, NATTkA does not need it, and is
redundant to the "Stabilization Request" component of the "Gentoo
Linux" product, under which stabilization requests are filled.

Signed-off-by: Florian Schmaus <flow@gentoo.org>