### PR TITLE
devbook-guide: Remove warning about newlines in title element

### DIFF
--- a/appendices/devbook-guide/text.xml
+++ b/appendices/devbook-guide/text.xml
@@ -54,11 +54,6 @@ one chapter. Its <c>&lt;title&gt;</c> is used to set the title for the entire
 document.
 </p>
 
-<important>
-The <c>&lt;title&gt;</c> element cannot contain any newlines. Make sure it is
-in one line, including its opening and closing tags.
-</important>
-
 <p>
 All tags must be closed of course, so the document ends with:
 </p>


### PR DESCRIPTION
Apparently the underlying bug has been fixed in commit b5bfc69.
