### PR TITLE
profiles: mention PMS as the main source of documentation

### DIFF
--- a/profiles/text.xml
+++ b/profiles/text.xml
@@ -5,8 +5,12 @@
 
 <body>
 <p>
-This section provides details on the <c>profiles/</c> directory. All of these files
-are also documented in <c>man portage</c>.
+This section provides details on the <c>profiles/</c> directory. All of these
+files are also documented in <c>man portage</c>, but the canonical reference
+for profiles is within
+<uri link="https://projects.gentoo.org/pms/8/pms.html#x1-320004.4">PMS</uri>.
+
+Portage-specific behaviour must not be relied upon in the repository.
 </p>
 </body>
 


### PR DESCRIPTION
While `man portage` may be a useful source of information,
it's not the "source of truth" on profiles - PMS is.

Reported-by: Joshua Kinard <kumba@gentoo.org>
Signed-off-by: Sam James <sam@gentoo.org>