### PR TITLE
general-concepts/dependencies: clarify strong blocker usage

### DIFF
--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -305,6 +305,12 @@ the package from source, and may not apply once the package is installed
 or when it is installed from a binary package.
 </p>
 
+<p>
+The most common use for strong blockers is where another package simply
+being installed causes a build failure. Strong blockers are not to be used
+to prevent just file collisions.
+</p>
+
 <note>
 If both weak and strong blockers match a given package, the strong blocker
 takes precedence.


### PR DESCRIPTION
Noticed we could be a bit clearer in the devmanual after
a discussion on a PR [0]. We've had a lot of confusion over
when it's appropriate to use strong blockers, so I think giving
a non-abstract "example" is helpful here.

[0] https://github.com/gentoo/gentoo/pull/22433#discussion_r720746670

Signed-off-by: Sam James <sam@gentoo.org>