### PR TITLE
ebuild-writing/eapi: document upgrade path policy

### DIFF
--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -83,6 +83,15 @@ governing their use of newer EAPIs, as does the
 <uri link="https://dev.gentoo.org/~mgorny/python-guide/package-maintenance.html#porting-packages-to-a-new-eapi">Python project</uri>.
 </p>
 
+<p>
+It is also convention that blockers within ebuilds are retained for at least
+2 years after the last ebuild matching the block is removed from the tree to
+avoid file collisions for users upgrading older systems. <c>pkgcheck</c> has
+a warning for this called <c>OutdatedBlocker</c> (or even
+<c>NonexistentBlocker</c> for when the match is from pre-git times if using
+a non-grafted repository).
+</p>
+
 </body>
 </subsection>
 </section>

--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -62,8 +62,29 @@ EAPI-conditional code)
 When writing new ebuilds developers can choose whatever EAPI they think
 is the best.  Using the features of the latest EAPI is encouraged.
 </p>
+</body>
+
+<subsection>
+<title>Upgrade path</title>
+<body>
+
+<p>
+Gentoo policy is to support upgrades for installations at least a year old
+with no/little intervention and up to two years old with minor intervention. To
+achieve this, developers must avoid using the latest EAPI in ebuilds within
+the <c>@system</c> set (see <uri link="::general-concepts/dependencies/#implicit-system-dependency"/>)
+or its dependencies.
+</p>
+
+<p>
+The Base System project has
+<uri link="https://wiki.gentoo.org/wiki/Project:Base#Rules_and_limitations">rules</uri>
+governing their use of newer EAPIs, as does the
+<uri link="https://dev.gentoo.org/~mgorny/python-guide/package-maintenance.html#porting-packages-to-a-new-eapi">Python project</uri>.
+</p>
 
 </body>
+</subsection>
 </section>
 
 <section>


### PR DESCRIPTION
The "upgrade path" policy is not particularly well-defined;
over the years, various people have come to understand it
as "two years", "one year", with mixed interpretations
within that (is it enough to be able to upgrade just
Portage?)

This is a start towards formalising policy here,
even if we end up changing it later, at least
it's codified.

Closes: https://bugs.gentoo.org/821553
Signed-off-by: Sam James <sam@gentoo.org>