### PR TITLE
keywording: note that stabilization rules are for actual testing

### DIFF
--- a/keywording/text.xml
+++ b/keywording/text.xml
@@ -379,6 +379,11 @@ Vulnerability Treatment Policy</uri>.
 <title>Stabilization rules</title>
 <body>
 
+<p>
+These are rules for stabilizing packages <e>by yourself</e> on a particular
+architecture, <e>not</e> for filing bugs to request arch teams to handle it.
+</p>
+
 <ul>
   <li>
      <c>amd64</c>, <c>x86</c>: If you are the maintainer of a package and own


### PR DESCRIPTION
These rules are for maintainers wishing to stable if they have
access to hardware -- they do _not_ mean maintainers must
follow these rules just to file a bug and stabilise a package
via CCing arch teams (the usual route).

Closes: https://bugs.gentoo.org/546942
Signed-off-by: Sam James <sam@gentoo.org>