### PR TITLE
eclass-writing: fix typo jmake-src_compile -> jmake_src_compile

### DIFF
--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -708,7 +708,7 @@ jmake-build() {
 	jmake dep &amp;&amp; jmake build "$@"
 }
 
-# @FUNCTION: jmake-src_compile
+# @FUNCTION: jmake_src_compile
 # @DESCRIPTION:
 # Calls jmake-configure() and jmake-build() to compile a jmake project.
 jmake_src_compile() {


### PR DESCRIPTION
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>