### PR TITLE
bin/gen-eclass-html.sh: Don't show mailto links

### DIFF
--- a/bin/gen-eclass-html.sh
+++ b/bin/gen-eclass-html.sh
@@ -149,6 +149,7 @@ for i in "${MANPAGES[@]}"; do
 		-e 's:<A HREF="\.\./man[^"]*">\([^<>]*\)</A>:\1:g' \
 		-e 's:<A HREF="[^"]*//localhost/[^"]*">\([^<>]*\)</A>:\1:g' \
 		-e 's:<A HREF="[^"]*\${[^"]*">\([^<>]*\)</A>:\1:g' \
+		-e 's,<A HREF="mailto:[^"]*">\([^<>]*\)</A>,\1,g' \
 		-e 's:<TT>\([^<>]*\)</TT>:\1:g' \
 		-e 's:<DL COMPACT>:<DL>:g' \
 		-e 's:<TR VALIGN=top>:<TR>:g' \


### PR DESCRIPTION
man2html's heuristic for recognition of e-mail addresses is
unreliable, therefore drop them all.

Reported-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
Signed-off-by: Ulrich Müller <ulm@gentoo.org>