### PR TITLE
eclass-writing: minor edits to jmake example

### DIFF
--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -801,7 +801,7 @@ functions.
 # @DESCRIPTION:
 # Demonstrates EXPORT_FUNCTIONS and defines simple wrappers for the
 # (hypothetical) jmake build system along with default src_configure and
-# src_compile phase functions
+# src_compile phase functions.
 
 case ${EAPI} in
 	7|8) ;;
@@ -825,7 +825,7 @@ jmake-configure() {
 # @FUNCTION: jmake_src_configure
 # @USAGE: [additional-args]
 # @DESCRIPTION:
-# Calls jmake-configure() to configure a jmake project. Passes all arguments
+# Calls jmake-configure() to configure a jmake project.  Passes all arguments
 # through to the appropriate "jmake configure" command.
 jmake_src_configure() {
 	jmake-configure "$@" || die "configure failed"


### PR DESCRIPTION
Double space after full stop. Add full stop to sentence.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>