### PR TITLE
devbook.xsl: Eclass documentation needs GPL-2 in the footer

### DIFF
--- a/devbook.xsl
+++ b/devbook.xsl
@@ -665,7 +665,15 @@
               <small>
                 Gentoo is a trademark of the Gentoo Foundation, Inc.
                 The text of this document is distributed under the
-                <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+                <xsl:choose>
+                  <!-- Eclasses are GPL-2, so we need a different footer -->
+                  <xsl:when test="starts-with(/guide/@self, 'eclass-reference/') and $relative_path_depth &gt;= 2">
+                    <a href="https://www.gnu.org/licenses/gpl-2.0.html">GNU General Public License, version 2</a>.
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+                  </xsl:otherwise>
+                </xsl:choose>
                 The <a href="https://www.gentoo.org/inside-gentoo/foundation/name-logo-guidelines.html">Gentoo Name and Logo Usage Guidelines</a> apply.
               </small>
             </div>


### PR DESCRIPTION
Eclasses are licensed GPL-2, therefore we need a different footer.
Hardcode this for all sub-pages of eclass-reference/.

Signed-off-by: Ulrich Müller &lt;ulm@gentoo.org&gt;