### PR TITLE
devbook.{rnc,xsl}: Add license element

### DIFF
--- a/devbook.rnc
+++ b/devbook.rnc
@@ -18,9 +18,12 @@ start = guide
 
 guide = element guide {
   (attribute root { "true" } | attribute self { text }),
+  license?,
   chapter,
   \include*
 }
+
+license = element license { "CC-BY-SA-4.0" | "GPL-2" }
 
 \include = element include { attribute href { text } }
 

--- a/devbook.rng
+++ b/devbook.rng
@@ -70,10 +70,21 @@
         </attribute>
         <attribute name="self"/>
       </choice>
+      <optional>
+        <ref name="license"/>
+      </optional>
       <ref name="chapter"/>
       <zeroOrMore>
         <ref name="include"/>
       </zeroOrMore>
+    </element>
+  </define>
+  <define name="license">
+    <element name="license">
+      <choice>
+        <value>CC-BY-SA-4.0</value>
+        <value>GPL-2</value>
+      </choice>
     </element>
   </define>
   <define name="include">

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -636,7 +636,7 @@
       </header>
       <main>
         <div class="container">
-          <xsl:apply-templates/>
+          <xsl:apply-templates select="/guide/chapter"/>
         </div>
       </main>
       <footer>
@@ -666,8 +666,7 @@
                 Gentoo is a trademark of the Gentoo Foundation, Inc.
                 The text of this document is distributed under the
                 <xsl:choose>
-                  <!-- Eclasses are GPL-2, so we need a different footer -->
-                  <xsl:when test="starts-with(/guide/@self, 'eclass-reference/') and $relative_path_depth &gt;= 2">
+                  <xsl:when test="/guide/license = 'GPL-2'">
                     <a href="https://www.gnu.org/licenses/gpl-2.0.html">GNU General Public License, version 2</a>.
                   </xsl:when>
                   <xsl:otherwise>


### PR DESCRIPTION
Eclasses are licensed GPL-2, therefore we need a different footer.
Introduce an optional license element which defaults to CC-BY-SA-4.0.

Eclass documentation would then set the license with:
&lt;license&gt;GPL-2&lt;/license&gt;

Signed-off-by: Ulrich Müller &lt;ulm@gentoo.org&gt;