### PR TITLE
general-concepts/ebuild-revisions: clarify interaction with adding/removing USE flags

### DIFF
--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -103,8 +103,14 @@ of thumb could be used as a guideline:
     (unless it is also a runtime dependency),
   </li>
   <li>
-    adding a new USE flag or removing an existing one (since change
-    in USE flags is going to trigger <c>--changed-use</c> rebuild),
+    adding a new USE flag if it controls a USE-dependency where the
+    functionality was hard-disabled in the build system before,
+  </li>
+  <li>
+    removing an existing USE flag if it controls a USE-dependency where the
+    functionality is now disabled entirely, rather than always being enabled
+    (since the change in USE flags is going to trigger a <c>--changed-use</c>
+    rebuild),
   </li>
   <li>
     a trivial stylistic / ebuild code change (as long as the new code


### PR DESCRIPTION
Note that when adding a USE flag where the functionality was previously on
(not off in build system), one must revbump
because a dep was unconditional that now became conditional.

Also, if removing a USE flag where the behaviour is now on, but was previously
always off (not on in build system), one must revbump also,
because people might have never set USE=foo (hence --changed-use wouldn't pick
it up) but their deps have now effectively changed.

Bug: https://github.com/pkgcore/pkgcheck/pull/435
Signed-off-by: Sam James <sam@gentoo.org>