### PR TITLE
Revert "ebuild-maintenance/removal: Process for virtual removal"

### DIFF
--- a/ebuild-maintenance/removal/text.xml
+++ b/ebuild-maintenance/removal/text.xml
@@ -113,10 +113,8 @@ In order to remove a virtual package, follow the following procedure:
     Wait the time appropriate for the last rites.
   </li>
   <li>
-    Update all ebuilds not to reference the virtual. Since there is
-    no urgent need to remove the virtual from user systems
-    and the resulting rebuilds would be unnecessary, do not bump ebuilds
-    when replacing the dependency.
+    Update all ebuilds not to reference the virtual, following normal
+    <uri link="::general-concepts/ebuild-revisions/"/> policy
   </li>
   <li>
     Remove the package directly

--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -108,11 +108,6 @@ of thumb could be used as a guideline:
   <li>
     a dependency change that is a result of a package move (slot move),
   </li>
-  <li>
-    a dependency change due to
-    <uri link="::ebuild-maintenance/removal/#Removing a virtual package">
-    removal of a virtual package</uri>.
-  </li>
 </ul>
 
 </body>


### PR DESCRIPTION
ebuild-maintenance/removal: Change inconsistent virtual revbump policy

This partly reverts commit f28b85f069c70538c618a3cedece77a359601dd8.

There's no reason to treat virtuals differently here, there's no
exception for it in how Portage works, and there's been various
cases of it causing upgrade difficulties for users (including
but in-no-way limited to https://archives.gentoo.org/gentoo-dev/message/64c42804eb4cf4bc7d1161a2e9222c6a).

The last big examples being virtual/emacs & virtual/pam which led
to a long-tail of issues in #gentoo.

It's also led to extensive confusion with contributors & new
developers as we have to try to explain the inconsistency
between devmanual and policy for non-virtuals.

See: https://github.com/gentoo/gentoo/pull/27637
Signed-off-by: Sam James <sam@gentoo.org>