### PR TITLE
ebuild-writing/eapi: Replace interactive by live in example

### DIFF
--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -1072,7 +1072,7 @@ EAPI=7
 
 inherit git-r3
 
-PROPERTIES+=" interactive"
+PROPERTIES+=" live"
 </codesample>
 
     <p>
@@ -1086,7 +1086,7 @@ EAPI=8
 
 inherit git-r3
 
-PROPERTIES="interactive"
+PROPERTIES="live"
 </codesample>
 
     <p>


### PR DESCRIPTION
The former is semi-deprecated and we shouldn't advertise its use.
