### PR TITLE
general-concepts/dependencies: use <c> tag for dev-util/ebuildtester

### DIFF
--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -702,7 +702,7 @@ package:
   <dd>
     A sure-way to find missing dependencies is to test your ebuild in a
     deprived environment. Chroots, containers, virtual machines and
-    dev-util/ebuildtester can achieve this.
+    <c>dev-util/ebuildtester</c> can achieve this.
   </dd>
 </dl>
 


### PR DESCRIPTION
This change highlights the `ebuildtester` package in a manner consistent with how other packages are presented throughout the document.