### PR TITLE
ebuild-writing, function-reference: Update eqawarn documentation

### DIFF
--- a/ebuild-writing/messages/text.xml
+++ b/ebuild-writing/messages/text.xml
@@ -99,9 +99,10 @@ is mainly used for displaying additional error details before bailing out.
 <body>
 
 <p>
-	The <c>eqawarn</c> function can be used by eclass authors to notify ebuild writers about
-	deprecated functionality. eqawarn is defined in eutils prior to EAPI=7. Portage doesn't log the qa message
-	class by default so users don't get annoyed by seeing messages they can't do much about.
+The <c>eqawarn</c> function can be used by eclass authors to notify ebuild
+writers about deprecated functionality. Portage doesn't log the qa message
+class by default so users don't get annoyed by seeing messages they can't do
+much about.
 </p>
 
 </body>

--- a/function-reference/message-functions/text.xml
+++ b/function-reference/message-functions/text.xml
@@ -79,8 +79,8 @@ displaying informational messages.
       <c>eqawarn</c>
     </ti>
     <ti>
-      Used by eclass authors to notify ebuild writers that they are using deprecated functionality.
-      Before EAPI=7, the eutils eclass must be inherited.
+      Used by eclass authors to notify ebuild writers that they are using
+      deprecated functionality.
     </ti>
   </tr>
 </table>


### PR DESCRIPTION
No longer mention eutils.eclass for eqawarn.