### PR TITLE
lang.highlight.*.xsl: Call our own subtokenate template

### DIFF
--- a/xsl/lang.highlight.c.xsl
+++ b/xsl/lang.highlight.c.xsl
@@ -53,7 +53,7 @@
       <!-- If we're inside quotes stop here -->
       <xsl:when test="$quotePos mod 2 != 0">
         <span class="Constant">
-        <xsl:call-template name="lang.highlight.ebuild.subtokenate">
+        <xsl:call-template name="lang.highlight.c.subtokenate">
           <xsl:with-param name="data"><xsl:value-of select="."/></xsl:with-param>
           <xsl:with-param name="nokeywords">True</xsl:with-param>
         </xsl:call-template>

--- a/xsl/lang.highlight.m4.xsl
+++ b/xsl/lang.highlight.m4.xsl
@@ -116,7 +116,7 @@
       <!-- If we're inside quotes stop here -->
       <xsl:when test="$quotePos mod 2 != 0">
         <span class="Constant">
-        <xsl:call-template name="lang.highlight.ebuild.subtokenate">
+        <xsl:call-template name="lang.highlight.m4.subtokenate">
           <xsl:with-param name="data"><xsl:value-of select="."/></xsl:with-param>
           <xsl:with-param name="nokeywords">True</xsl:with-param>
         </xsl:call-template>

--- a/xsl/lang.highlight.make.xsl
+++ b/xsl/lang.highlight.make.xsl
@@ -20,15 +20,15 @@
       </xsl:when>
 
       <xsl:when test="contains($data, '$(')">
-        <xsl:call-template name="lang.highlight.m4.subtokenate">
+        <xsl:call-template name="lang.highlight.make.subtokenate">
           <xsl:with-param name="data" select="substring-before($data, '$(')"/>
           <xsl:with-param name="nokeywords" select="$nokeywords"/>
         </xsl:call-template>
-        <span class="Identifier">$(<xsl:call-template name="lang.highlight.m4.subtokenate">
+        <span class="Identifier">$(<xsl:call-template name="lang.highlight.make.subtokenate">
           <xsl:with-param name="data" select="substring-before(substring-after($data, '$('), ')')"/>
           <xsl:with-param name="nokeywords" select="$nokeywords"/>
         </xsl:call-template>)</span>
-        <xsl:call-template name="lang.highlight.m4.subtokenate">
+        <xsl:call-template name="lang.highlight.make.subtokenate">
           <xsl:with-param name="data" select="substring-after(substring-after($data, '$('), ')')"/>
           <xsl:with-param name="nokeywords" select="$nokeywords"/>
         </xsl:call-template>


### PR DESCRIPTION
These called templates of other highlighting modules, which looks like an oversight.

The only differences in the generated HTML code are in two of the code samples in general-concepts/autotools.