### PR TITLE
Some minor changes to wording and style

### DIFF
--- a/function-reference/query-functions/text.xml
+++ b/function-reference/query-functions/text.xml
@@ -23,7 +23,7 @@ query variables and similar state.
       <c>use flagname</c>
     </ti>
     <ti>
-      Returns a true value if and only if <c>flagname</c> is enabled.
+      Returns a true value if <c>flagname</c> is enabled, false otherwise.
       The condition is inverted if prefixed with an exclamation mark,
       <c>!flagname</c>.
       It is guaranteed that <c>use</c> produces no output.

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -462,7 +462,7 @@ sub-slot changes of <c>wombat:0</c> should be ignored.
 <body>
 
 <p>
-To depend upon a certain package if and only if a given <c>USE</c> flag is set:
+To depend upon a certain package only if a given <c>USE</c> flag is set:
 </p>
 
 <codesample lang="ebuild">

--- a/tools-reference/echo/text.xml
+++ b/tools-reference/echo/text.xml
@@ -47,7 +47,7 @@ As of &gt;=bash-2.05b, the so-called "here strings" have been
 introduced. Using "here strings", you can pass contents of an
 environment variable to the standard input of an application, using
 <c>&lt;&lt;&lt;word</c> redirection: what actually happens is
-that <c>bash</c> expands word and passes the result to the standard
+that <c>bash</c> expands <c>word</c> and passes the result to the standard
 input.
 </p>
 

--- a/tools-reference/echo/text.xml
+++ b/tools-reference/echo/text.xml
@@ -29,12 +29,12 @@ the same as the former, but they won't print the trailing newline
 
 <p>
 All usage of the form <c>echo ${somevar} | grep substring</c> just to
-check if the content of the <c>${somevar}</c> variable
-contains <c>substring</c>, or more often, <c>echo ${somevar} |
-command</c>, is deprecated and should be (and in most cases, can be)
-used as less as possible: doing so involves for no reason an
-additional shell session and a pipe. The "here strings" section
-describes the preferred way of dealing with such cases.
+check if the content of the <c>${somevar}</c> variable contains
+<c>substring</c>, or more often, <c>echo ${somevar} | command</c>,
+is deprecated and should be (and in most cases, can be) avoided:
+doing so involves for no reason an additional shell session and a pipe.
+The "here strings" section describes the preferred way
+of dealing with such cases.
 </p>
 </body>
 </section>

--- a/tools-reference/grep/text.xml
+++ b/tools-reference/grep/text.xml
@@ -32,9 +32,8 @@ being a fixed string rather than a regular expression.
 
 <p>
 By default, <c>grep</c> prints out matching lines from the input. If
-<c>-q</c> is specified, no output is displayed. If <c>-l</c> (lowercase
-letter ell) is specified, only the filenames of files which contain
-matching lines are displayed.
+<c>-q</c> is specified, no output is displayed. If <c>-l</c> is specified,
+only the filenames of files which contain matching lines are displayed.
 </p>
 
 <p>


### PR DESCRIPTION
Hi Gentoo friends, here are, in my opinion, more possible improvements to devmanual.

I put this in 4 commits to make every change atomic, if desired, I can change it to more or less commits. 

There's some reasoning for the proposed changes in the commit messages, 
but below is a little more elaborate reasoning and I'm also very open to discussion:


### tools-reference/echo: Improve wording in abuse chapter

"All usage of [...] is deprecated and should be used as less as possible."
While this can be understood, in my opinion, the proper way of saying this is either "as rarely as possible" or "as little as possible". I chose the former.


### general-concepts/dependencies + function-reference/query-functions: Remove double if constraints

The term "if and only if" is used in mathematics and logic, but looking at the PMS chapters about "use" and "USE dependencies", I don't see how that would apply here and I therefore believe it is just unnecessary cruft that nobody ever questioned and the regular "only if" would suffice and it would feel less bumpy when reading. If that is true, remove it. If not, enlighten me please :-)


### tools-reference/grep: Remove the phonetic spelling of the -l parameter

I understand that depending on browser font one could confuse l with the number 1. However it is always possible to just copy/paste the parameter so it can't be confused. In my font of the devmanual, those two are also clearly distinguishable. In any case, if this _really_ serves a purpose here, I 'd change it to "lowercase L" but preferably remove it. It is also not specified this way or spelled phonetically on other devmanual pages (like e.g. sed's \l). This is the only occurence I found.


### tools-reference/echo: Format the "word" variable as inline code

The devmanual commonly uses <c> to format variables in text passages as code to make them more distinguishable from the rest of the text and that's why I think it should be done here too.