### PR TITLE
Some minor content edits and corrections

### DIFF
--- a/archs/x86/text.xml
+++ b/archs/x86/text.xml
@@ -29,12 +29,6 @@ The following is a list of rules and expectations for members of the x86 team:
 
 <ul>
   <li>
-    Assist/resolve 4 bugs a month that are assigned to the team
-  </li>
-  <li>
-    Be present in our IRC channel, <c>#gentoo-x86/irc.libera.chat</c>
-  </li>
-  <li>
     If you need one of your packages stable, file a bug to the team.  You are not
     exempt from the same rules everyone else must follow.
   </li>

--- a/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
@@ -25,10 +25,8 @@ manner such as:
 
 <codesample lang="ebuild">
 src_unpack() {
-	rpm_src_unpack ${A}
-	cd "${S}"
-
-	use ssl &amp;&amp; eapply "${FILESDIR}/${PV}/${P}-ssl.patch"
+	unpack ${A}
+	rpm_unpack "${S}/rpm/intel-openclrt-${PV}-${ALT_PV}.x86_64.rpm"
 }
 </codesample>
 

--- a/ebuild-writing/messages/text.xml
+++ b/ebuild-writing/messages/text.xml
@@ -148,12 +148,12 @@ It would be better written as:
 </p>
 
 <codesample lang="ebuild">
-ewarn "The 'frozbinate' function provided by eutils.eclass is deprecated"
-ewarn "in favour of frozbinate.eclass, but this package has not been"
-ewarn "updated yet. If this is a package from the main tree, please check"
-ewarn "https://bugs.gentoo.org/ and file a bug if there is not one already."
-ewarn "If this is your own package, please read the comments in the"
-ewarn "frozbinate eclass for instructions on how to convert."
+eqawarn "The 'frozbinate' function provided by eutils.eclass is deprecated"
+eqawarn "in favour of frozbinate.eclass, but this package has not been"
+eqawarn "updated yet. If this is a package from the main tree, please check"
+eqawarn "https://bugs.gentoo.org/ and file a bug if there is not one already."
+eqawarn "If this is your own package, please read the comments in the"
+eqawarn "frozbinate eclass for instructions on how to convert."
 </codesample>
 
 </body>

--- a/general-concepts/portage-cache/text.xml
+++ b/general-concepts/portage-cache/text.xml
@@ -58,7 +58,8 @@ fi
 Because eclasses modify various cached variables, conditional inheritance is not
 allowed except where the same results will always be obtained on every system.
 For example, inherits based upon <c>USE</c> flags are illegal, but inherits based
-solely upon <c>PN</c> are allowed.
+solely upon the unchanging variables (e.g. <c>PV</c>) mentioned above are
+allowed.
 </p>
 
 <p>


### PR DESCRIPTION
Hi Gentoo friends, here are some more edits that I'd propose. 

There's some short reasoning for the proposed changes in the commit messages, 
but below is a little more elaborate text and I'm also very open to discussion. 
Please have a critical look, because I'm new to this. All this is just stuff I noticed while reading the devmanual.


### general-concepts/portage-cache: Add PV as example for valid conditional inherits

The [code example](https://devmanual.gentoo.org/general-concepts/portage-cache/index.html#conditional-inherits) is the commonly used ${PV} == 9999. It uses PV for the
conditional inherit. The preceding text that explains conditional inherits only
mentions PN as valid. This is either a typo and should state PV or as I see
it both are correct, then the explaining text should at least mention PN and PV


### src_unpack/rpm-sources: Replace src_unpack override example code

This replaces the [code example](https://devmanual.gentoo.org/ebuild-writing/functions/src_unpack/rpm-sources/index.html) with a snippet of how it is currently used in
::gentoo/dev-util/intel-ocl-sdk/intel-ocl-sdk-18.1.0.015.ebuild
because the old example code - in my opinion - has multiple issues.
Firstly, it uses ${A} as argument for rpm_src_unpack. Current rpm eclass does
not accept any arguments for rpm_src_unpack and always unpacks ${A}. 
Secondly, the example uses eapply in src_unpack() but eapply should IMHO rather
be used in src_prepare(), so at least it is not a good role model. 


### archs/x86: Remove the minimum resolved bugs quota

[This](https://devmanual.gentoo.org/archs/x86/index.html#x86-team-guidelines) feels like old cruft and according to sam it can be removed


### ebuild-writing/messages: Change eawarn to eqawarn in the example code

The [message in the code block](https://devmanual.gentoo.org/ebuild-writing/messages/index.html#good-and-bad-messages) is clearly a message from an eclass author to 
ebuild developers and therefore should use eqawarn and not ewarn, like the 
"QA warnings" passage above describes. 
However, the question then arises, should it even be kept in this
"ebuild-writing" chapter, when it actually rather belongs to "eclass-writing". 
But eclass-writing does not have a separate "Messages" chapter and it works for
explaining good and bad messages here