### PR TITLE
Remove some nostalgia

### DIFF
--- a/ebuild-writing/messages/text.xml
+++ b/ebuild-writing/messages/text.xml
@@ -38,9 +38,8 @@ internal is the simplest <d/> it simply displays its parameters as a message.
 
 <p>
 The <c>elog</c> function can be used to display an informational message which is
-meant to 'stand out' and is logged by the elog functionality in Portage 2.1 and
-Paludis 0.6 or newer.  On a colour terminal, the message provided will be prefixed
-with a green asterisk.  On earlier versions, elog behaves just like einfo.
+meant to 'stand out' and is logged by Portage's elog functionality. On a colour
+terminal, the message provided will be prefixed with a green asterisk.
 </p>
 
 <codesample lang="ebuild">

--- a/tools-reference/echo/text.xml
+++ b/tools-reference/echo/text.xml
@@ -43,8 +43,7 @@ of dealing with such cases.
 <title>Here strings</title>
 <body>
 <p>
-As of &gt;=bash-2.05b, the so-called "here strings" have been
-introduced. Using "here strings", you can pass contents of an
+Using "here strings", you can pass contents of an
 environment variable to the standard input of an application, using
 <c>&lt;&lt;&lt;word</c> redirection: what actually happens is
 that <c>bash</c> expands <c>word</c> and passes the result to the standard


### PR DESCRIPTION
Hi Gentoo friends, this is the last part of my devmanual review.

Today I propose removals of old cruft that - in my opinion - serves no purpose any more.

This is often a hot topic but I thought I'll just float the idea and see how it is received.


### tools-reference/echo: Remove bash version history

Those bash "here strings" were introduced 22 years ago and [stating the bash version](https://devmanual.gentoo.org/tools-reference/echo/index.html#here-strings) they were implemented does not serve any purpose any more. It has become common functionality and Gentoo generally requires at least bash-4.2 (EAPI=6)


### ebuild-writing/messages: Remove history lesson

The [mentioned versions](https://devmanual.gentoo.org/ebuild-writing/messages/index.html#information-messages) are over 18 years old and the elog functionality has become common. There is no value in stating when it was implemented. Removed Paludis too, because it has no relevance for Gentoo. (unlike maybe for PMS, but this is the Gentoo devmanual. Paludis is also not in any repository/overlay)
