### PR TITLE
g-c/dependencies: Clarify the stance on circular dependencies

### DIFF
--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -821,6 +821,14 @@ There are three kinds of circular dependencies:
   </li>
 </ol>
 
+<p>
+While circular dependencies should be avoided, an exception can be made for
+test-only dependencies. Similar to the example above with the tests of
+<c>dev-python/setuptools</c>, if a package needs itself, directly or
+indirectly, in order to run its tests, it is usually fine to leave it
+as-is. You should fix it if you can but don't go to extensive lengths for it.
+</p>
+
 </body>
 </section>
 


### PR DESCRIPTION
I had a package that needed changes that would introduce a dependency cycle with USE=test and I had to ask on IRC whether this was OK. Sam told me not to worry about it and recommended that the devmanual should note this.

So, add a paragraph that discourages dependency cycles but expresses that cycles provoked by USE=test can usually be ignored.