### PR TITLE
general-concepts/ebuild-revisions: mention balancing examples against…

### DIFF
--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -125,6 +125,11 @@ of thumb could be used as a guideline:
   </li>
 </ul>
 
+<p>
+Note that the examples above should still be balanced against the general
+principle of conservatism and need to minimize risk for stable users.
+</p>
+
 </body>
 </chapter>
 </guide>


### PR DESCRIPTION
… stable

Explicitly say that even 'no revision bump' examples should be balanced against whether a stable ebuild is being modified, as we want to minimize any risk of regressions there.

i.e. It might be that a change would not need a revbump for an ~arch-only ebuild, but if the ebuild is stable, the principle of being conservative ofr stable would mean a revbump is warranted.