### PR TITLE
Rename the document element from "guide" to "devbook"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ install: all
 
 validate: devbook.rng
 	@xmllint --noout --quiet --relaxng $< $(XMLS)
-	@# Check if /guide/@self agrees with the document path
+	@# Check if /devbook/@self agrees with the document path
 	@for file in $(XMLS); do \
-	  self=$$(xmllint --quiet --xpath 'string(/guide/@self)' $${file}); \
+	  self=$$(xmllint --quiet --xpath 'string(/devbook/@self)' $${file}); \
 	  if test "$${self}text.xml" != "$${file#./}"; then \
 	    echo "$${file}: bad self attribute '$${self}'"; exit 1; \
 	  fi; \

--- a/appendices/common-problems/text.xml
+++ b/appendices/common-problems/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/common-problems/">
+<devbook self="appendices/common-problems/">
 <chapter>
 <title>Common problems</title>
 <body>
@@ -195,4 +195,4 @@ by tricking the build system into using a safer location. See
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/appendices/contributing/text.xml
+++ b/appendices/contributing/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/contributing/">
+<devbook self="appendices/contributing/">
 <chapter>
 <title>Contributing to this document</title>
 
@@ -144,4 +144,4 @@ amount of depth.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/appendices/contributors/text.xml
+++ b/appendices/contributors/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/contributors/">
+<devbook self="appendices/contributors/">
 <chapter>
 <title>Contributions</title>
 <body>
@@ -133,4 +133,4 @@ This page lists the contributions to the Gentoo Development Guide:
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/appendices/devbook-guide/text.xml
+++ b/appendices/devbook-guide/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/devbook-guide/">
+<devbook self="appendices/devbook-guide/">
 <chapter>
 <title>Gentoo DevBook XML guide</title>
 
@@ -34,18 +34,18 @@ used in a DevBook XML document:
 
 <codesample lang="sgml" caption="The preamble of a DevBook XML document">
 &lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;guide self="appendices/devbook-guide/"&gt;
+&lt;devbook self="appendices/devbook-guide/"&gt;
 &lt;chapter&gt;
 &lt;title&gt;Gentoo DevBook XML guide&lt;/title&gt;
 </codesample>
 
 <p>
 On the first lines, we see the XML declaration that identifies this as an XML
-document. Next, there's a <c>&lt;guide&gt;</c> tag <d/> the entire document is
-enclosed within a <c>&lt;guide&gt; &lt;/guide&gt;</c> pair. Its <c>self</c>
+document. Next, there's a <c>&lt;devbook&gt;</c> tag <d/> the entire document is
+enclosed within a <c>&lt;devbook&gt; &lt;/devbook&gt;</c> pair. Its <c>self</c>
 attribute must point to the relative path of the document from the root node;
 in the example above the path is <c>appendices/devbook-guide/</c>. An exception
-is the root node itself, which has <c>&lt;guide root="true"&gt;</c> instead.
+is the root node itself, which has <c>&lt;devbook root="true"&gt;</c> instead.
 </p>
 
 <p>
@@ -60,7 +60,7 @@ All elements must be closed of course, so the document ends with:
 
 <codesample lang="sgml">
 &lt;/chapter&gt;
-&lt;/guide&gt;
+&lt;/devbook&gt;
 </codesample>
 
 </body>
@@ -714,4 +714,4 @@ possible. In other words, the
 </subsection>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/appendices/devbook-guide/text.xml
+++ b/appendices/devbook-guide/text.xml
@@ -125,7 +125,7 @@ tag. Note that the trailing slash in the <c>href</c> value is mandatory.
 </p>
 
 <p>
-A table of contents can be generated with <c>&lt;contentsTree&gt;</c>.
+A table of contents can be generated with <c>&lt;contents/&gt;</c>.
 Typically, this would be the only element in its own section body, as in
 the following example:
 </p>
@@ -134,7 +134,7 @@ the following example:
 &lt;section&gt;
 &lt;title&gt;Contents&lt;/title&gt;
 &lt;body&gt;
-&lt;contentsTree/&gt;
+&lt;contents/&gt;
 &lt;/body&gt;
 &lt;/section&gt;
 </codesample>

--- a/appendices/editor-configuration/emacs/text.xml
+++ b/appendices/editor-configuration/emacs/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/editor-configuration/emacs/">
+<devbook self="appendices/editor-configuration/emacs/">
 <chapter>
 <title>Configuring GNU Emacs</title>
 
@@ -106,4 +106,4 @@ for each document type.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/appendices/editor-configuration/text.xml
+++ b/appendices/editor-configuration/text.xml
@@ -14,7 +14,7 @@ with ebuilds.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/appendices/editor-configuration/text.xml
+++ b/appendices/editor-configuration/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/editor-configuration/">
+<devbook self="appendices/editor-configuration/">
 <chapter>
 <title>Editor configuration</title>
 <body>
@@ -23,4 +23,4 @@ with ebuilds.
 <include href="emacs/"/>
 <include href="xemacs/"/>
 
-</guide>
+</devbook>

--- a/appendices/editor-configuration/vim/text.xml
+++ b/appendices/editor-configuration/vim/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/editor-configuration/vim/">
+<devbook self="appendices/editor-configuration/vim/">
 <chapter>
 <title>Configuring <c>vim</c> and <c>gvim</c></title>
 <body>
@@ -22,4 +22,4 @@ of interest. The ! is required to replace spaces with tabs.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/appendices/editor-configuration/xemacs/text.xml
+++ b/appendices/editor-configuration/xemacs/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/editor-configuration/xemacs/">
+<devbook self="appendices/editor-configuration/xemacs/">
 <chapter>
 <title>Configuring XEmacs for UTF-8</title>
 <body>
@@ -41,4 +41,4 @@ status line.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/appendices/further-reading/text.xml
+++ b/appendices/further-reading/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/further-reading/">
+<devbook self="appendices/further-reading/">
 <chapter>
 <title>Further reading</title>
 <body>
@@ -57,5 +57,5 @@ recommendations, not padding designed to make this document look important.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>
 

--- a/appendices/text.xml
+++ b/appendices/text.xml
@@ -12,7 +12,7 @@ This section incorporates various auxiliary documents which may be useful as a r
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/appendices/text.xml
+++ b/appendices/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/">
+<devbook self="appendices/">
 <chapter>
 <title>Appendices</title>
 
@@ -25,4 +25,4 @@ This section incorporates various auxiliary documents which may be useful as a r
 <include href="contributors/"/>
 <include href="todo-list/"/>
 
-</guide>
+</devbook>

--- a/appendices/todo-list/text.xml
+++ b/appendices/todo-list/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="appendices/todo-list/">
+<devbook self="appendices/todo-list/">
 <chapter>
 <title>TODO list</title>
 <body>
@@ -10,4 +10,4 @@ This TODO list is automatically generated from the <c>&lt;todo&gt;</c> directive
 <contentsTree root="" extraction="todo"/>
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/appendices/todo-list/text.xml
+++ b/appendices/todo-list/text.xml
@@ -7,7 +7,7 @@
 This TODO list is automatically generated from the <c>&lt;todo&gt;</c> directives in other documents.
 </p>
 
-<contentsTree root="" extraction="todo"/>
+<contents root="" extraction="todo"/>
 </body>
 </chapter>
 </devbook>

--- a/archs/alpha/text.xml
+++ b/archs/alpha/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="archs/alpha/">
+<devbook self="archs/alpha/">
 <chapter>
 <title>Arch specific notes — Alpha</title>
 <body>
@@ -155,4 +155,4 @@ The Alpha team can be contacted:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/archs/amd64/text.xml
+++ b/archs/amd64/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="archs/amd64/">
+<devbook self="archs/amd64/">
 <chapter>
 <title>Arch specific notes — AMD64/EM64T</title>
 
@@ -493,4 +493,4 @@ segmentation faults or strange behaviour. GCC 4.0 refuses to compile such code.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/archs/mips/text.xml
+++ b/archs/mips/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="archs/mips/">
+<devbook self="archs/mips/">
 <chapter>
 <title>Arch specific notes — MIPS</title>
 <body>
@@ -135,4 +135,4 @@ The MIPS team can be contacted:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/archs/ppc/text.xml
+++ b/archs/ppc/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="archs/ppc/">
+<devbook self="archs/ppc/">
 <chapter>
 <title>Arch specific notes — PPC</title>
 <body>
@@ -103,4 +103,4 @@ The PowerPC team can be reached by:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/archs/sparc/text.xml
+++ b/archs/sparc/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="archs/sparc/">
+<devbook self="archs/sparc/">
 <chapter>
 <title>Arch specific notes — SPARC</title>
 <body>
@@ -149,6 +149,6 @@ The SPARC team can be contacted:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>
 
 

--- a/archs/text.xml
+++ b/archs/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="archs/">
+<devbook self="archs/">
 <chapter>
 <title>Arch specific notes</title>
 <body>
@@ -34,4 +34,4 @@ happens to work best in any situation.
 <include href="sparc/"/>
 <include href="x86/"/>
 
-</guide>
+</devbook>

--- a/archs/text.xml
+++ b/archs/text.xml
@@ -22,7 +22,7 @@ happens to work best in any situation.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/archs/x86/text.xml
+++ b/archs/x86/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="archs/x86/">
+<devbook self="archs/x86/">
 <chapter>
 <title>Arch specific notes — x86</title>
 <body>
@@ -63,4 +63,4 @@ The x86 team can be contacted:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/bin/build_search_documents.py
+++ b/bin/build_search_documents.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright 2019 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU GPL version 2 or later
 import json
 import os.path
@@ -83,7 +83,7 @@ def process_node(documents: list, node: ET.Element, name: str, url: str) -> None
 
         for child in node:
             process_node(documents, child, name, url)
-    elif node.tag in ['body', 'dl', 'guide', 'ul', 'table', 'tr']:
+    elif node.tag in ['devbook', 'body', 'dl', 'ul', 'table', 'tr']:
         for child in node:
             process_node(documents, child, name, url)
     elif node.tag in ['p', 'dd', 'dt', 'important', 'li', 'note', 'warning', 'th', 'ti']:

--- a/bin/gen-eclass-html.sh
+++ b/bin/gen-eclass-html.sh
@@ -169,7 +169,7 @@ find "${OUTPUTDIR}" -mindepth 1 -maxdepth 1 -mtime +1 -exec rm -R {} \;
 # build the index, rebuilding it each time
 cat << 'EOF' > "${OUTPUTDIR}"/text.xml || exit 1
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="eclass-reference/">
+<devbook self="eclass-reference/">
 <chapter>
 <title>Eclass reference</title>
 <body>
@@ -212,7 +212,7 @@ fi
 
 cat << 'EOF' >> "${OUTPUTDIR}"/text.xml || exit 1
 </chapter>
-</guide>
+</devbook>
 EOF
 
 # Local Variables:

--- a/depend.xsl
+++ b/depend.xsl
@@ -12,7 +12,7 @@
 <xsl:template match="/">
   <xsl:variable name="refs">
     <!-- all descendants -->
-    <xsl:call-template name="contentsTree"/>
+    <xsl:call-template name="contents"/>
     <!-- all ancestors -->
     <xsl:call-template name="printParentDocs"/>
     <!-- previous and next documents -->

--- a/depend.xsl
+++ b/depend.xsl
@@ -19,7 +19,7 @@
     <xsl:call-template name="findPrevious"/>
     <xsl:call-template name="findNext"/>
   </xsl:variable>
-  <xsl:variable name="self" select="/guide/@self"/>
+  <xsl:variable name="self" select="/devbook/@self"/>
   <xsl:value-of select="concat($self, 'index.html:')"/>
   <xsl:for-each select="exslt:node-set($refs)//a/@href[. != '#']">
     <xsl:text> </xsl:text>

--- a/devbook.rnc
+++ b/devbook.rnc
@@ -33,7 +33,7 @@ subsubsection = element subsubsection { title, body }
 # Title texts are used as anchors, so allow only text attributes
 title = element title { attrib }
 
-body = element body { (authors | contentsTree | block.class)+ }
+body = element body { (authors | contents | block.class)+ }
 
 authors = element authors { author+ | authorlist+ }
 
@@ -48,7 +48,7 @@ authorlist = element authorlist {
   attribute href { text }
 }
 
-contentsTree = element contentsTree {
+contents = element contents {
   attribute maxdepth { xsd:unsignedInt }?,
   attribute root { text }?,
   attribute extraction { text }?

--- a/devbook.rnc
+++ b/devbook.rnc
@@ -14,9 +14,9 @@ attrib = attrib.class*
 inline = inline.class*
 all = (block.class | inline.class)*
 
-start = guide
+start = devbook
 
-guide = element guide {
+devbook = element devbook {
   (attribute root { "true" } | attribute self { text }),
   chapter,
   \include*

--- a/devbook.rng
+++ b/devbook.rng
@@ -62,10 +62,10 @@
     </zeroOrMore>
   </define>
   <start>
-    <ref name="guide"/>
+    <ref name="devbook"/>
   </start>
-  <define name="guide">
-    <element name="guide">
+  <define name="devbook">
+    <element name="devbook">
       <choice>
         <attribute name="root">
           <value>true</value>

--- a/devbook.rng
+++ b/devbook.rng
@@ -136,7 +136,7 @@
       <oneOrMore>
         <choice>
           <ref name="authors"/>
-          <ref name="contentsTree"/>
+          <ref name="contents"/>
           <ref name="block.class"/>
         </choice>
       </oneOrMore>
@@ -169,8 +169,8 @@
       <attribute name="href"/>
     </element>
   </define>
-  <define name="contentsTree">
-    <element name="contentsTree">
+  <define name="contents">
+    <element name="contents">
       <optional>
         <attribute name="maxdepth">
           <data type="unsignedInt"/>

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -361,7 +361,7 @@
       <xsl:variable name="path_rel">
         <xsl:call-template name="relative-path">
           <xsl:with-param name="path" select="$path"/>
-          <xsl:with-param name="self" select="/guide/@self"/>
+          <xsl:with-param name="self" select="/devbook/@self"/>
         </xsl:call-template>
       </xsl:variable>
       <xsl:variable name="path_html">
@@ -406,7 +406,7 @@
                 <xsl:value-of select="substring-before(substring-after($path, '/'), '/')"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="document(concat($path, 'text.xml'))/guide/chapter[1]/title"/>
+                <xsl:value-of select="document(concat($path, 'text.xml'))/devbook/chapter[1]/title"/>
               </xsl:otherwise>
             </xsl:choose>
           </a>
@@ -440,27 +440,27 @@
   <xsl:param name="path">
     <xsl:choose>
       <xsl:when test="@root"><xsl:value-of select="@root"/></xsl:when>
-      <xsl:otherwise><xsl:value-of select="/guide/@self"/></xsl:otherwise>
+      <xsl:otherwise><xsl:value-of select="/devbook/@self"/></xsl:otherwise>
     </xsl:choose>
   </xsl:param>
   <xsl:param name="path_rel">
-    <xsl:if test="$depth = 0 and $path = '' and /guide/@self != ''">
+    <xsl:if test="$depth = 0 and $path = '' and /devbook/@self != ''">
       <xsl:call-template name="repeat-string">
         <xsl:with-param name="count"
-                        select="string-length(/guide/@self) - string-length(translate(/guide/@self, '/' , ''))"/>
+                        select="string-length(/devbook/@self) - string-length(translate(/devbook/@self, '/' , ''))"/>
         <xsl:with-param name="string">../</xsl:with-param>
       </xsl:call-template>
     </xsl:if>
   </xsl:param>
-  <xsl:param name="orig_self" select="/guide/@self"/>
+  <xsl:param name="orig_self" select="/devbook/@self"/>
   <xsl:param name="extraction" select="@extraction"/>
   <xsl:param name="extraction_counting"/>
 
   <xsl:variable name="doc_self" select="concat($path, 'text.xml')"/>
-  <xsl:if test="count(document($doc_self)/guide/include) &gt; 0 and ($depth &lt; $maxdepth or $maxdepth = 0)">
+  <xsl:if test="count(document($doc_self)/devbook/include) &gt; 0 and ($depth &lt; $maxdepth or $maxdepth = 0)">
     <xsl:choose>
       <xsl:when test="$extraction_counting = 1">
-        <xsl:for-each select="document($doc_self)/guide/include">
+        <xsl:for-each select="document($doc_self)/devbook/include">
           <count value="{count(document(concat($path, @href, 'text.xml'))//*[name()=$extraction])}"
                  path="{concat($path, @href)}">
             <xsl:call-template name="contentsTree">
@@ -477,7 +477,7 @@
       </xsl:when>
       <xsl:otherwise>
         <ul>
-          <xsl:for-each select="document($doc_self)/guide/include">
+          <xsl:for-each select="document($doc_self)/devbook/include">
             <xsl:variable name="extraction_counter_node">
               <xsl:call-template name="contentsTree">
                 <xsl:with-param name="depth" select="$depth + 1"/>
@@ -495,17 +495,17 @@
             <xsl:if test="string($extraction) = '' or $extraction_counter &gt; 0">
               <li>
                 <a class="reference" href="{concat($path_rel, @href, 'index.html')}">
-                  <xsl:value-of select="document(concat($path, @href, 'text.xml'))/guide/chapter[1]/title"/>
+                  <xsl:value-of select="document(concat($path, @href, 'text.xml'))/devbook/chapter[1]/title"/>
                 </a>
                 <xsl:if test="$extraction != ''">
                   <!-- If the extracted element from the other document contains
                        any internal references, relative links would be based on
-                       the wrong start location. So we must replace /guide/@self
-                       by our own copy. Bug #916523. -->
+                       the wrong start location. So we replace /devbook/@self by
+                       our own copy. Bug #916523. -->
                   <xsl:variable name="document_tree">
-                    <guide self="{$orig_self}">
-                      <xsl:copy-of select="document(concat($path, @href, 'text.xml'))/guide/*"/>
-                    </guide>
+                    <devbook self="{$orig_self}">
+                      <xsl:copy-of select="document(concat($path, @href, 'text.xml'))/devbook/*"/>
+                    </devbook>
                   </xsl:variable>
                   <ul>
                     <xsl:for-each select="exslt:node-set($document_tree)//*[name()=$extraction]">
@@ -533,14 +533,14 @@
 <xsl:template match="/">
   <xsl:variable name="relative_path_depth_recursion">
     <xsl:call-template name="repeat-string">
-      <xsl:with-param name="count" select="string-length(/guide/@self)
-                                           - string-length(translate(/guide/@self, '/' , ''))"/>
+      <xsl:with-param name="count" select="string-length(/devbook/@self)
+                                           - string-length(translate(/devbook/@self, '/' , ''))"/>
       <xsl:with-param name="string">../</xsl:with-param>
     </xsl:call-template>
   </xsl:variable>
   <html lang="en">
     <head>
-      <title><xsl:value-of select="/guide/chapter[1]/title"/> &#x2013; Gentoo Development Guide</title>
+      <title><xsl:value-of select="/devbook/chapter[1]/title"/> &#x2013; Gentoo Development Guide</title>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta name="description" content="The Gentoo Devmanual is a technical manual which covers topics such as writing ebuilds and eclasses, and policies that developers should be abiding by." />
       <xsl:choose>
@@ -623,10 +623,10 @@
                       </li>
                       <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">Index&#xa0;<span class="caret"/></a>
-                        <xsl:if test="/guide/chapter[1]/section or /guide/include">
+                        <xsl:if test="/devbook/chapter[1]/section or /devbook/include">
                           <ul class="dropdown-menu">
                             <!-- List sections of this chapter first. -->
-                            <xsl:for-each select="/guide/chapter[1]/section">
+                            <xsl:for-each select="/devbook/chapter[1]/section">
                               <xsl:variable name="anchor">
                                 <xsl:call-template name="convert-to-anchor">
                                   <xsl:with-param name="data" select="title"/>
@@ -634,7 +634,7 @@
                               </xsl:variable>
                               <li><a class="reference" href="#{$anchor}"><xsl:value-of select="title"/></a></li>
                             </xsl:for-each>
-                            <xsl:if test="/guide/include">
+                            <xsl:if test="/devbook/include">
                               <li class="divider"><xsl:comment/></li>
                               <!-- List any sub-documents included at first level.
                                    We cannot call "contentsTree" directly, because it would
@@ -735,8 +735,8 @@
                 The text of this document is distributed under the
                 <xsl:choose>
                   <!-- Eclasses are GPL-2, so we need a different footer -->
-                  <xsl:when test="starts-with(/guide/@self, 'eclass-reference/')
-                                  and substring-after(/guide/@self, '/') != ''">
+                  <xsl:when test="starts-with(/devbook/@self, 'eclass-reference/')
+                                  and substring-after(/devbook/@self, '/') != ''">
                     <a href="https://www.gnu.org/licenses/gpl-2.0.html">GNU General Public License, version 2</a>.
                   </xsl:when>
                   <xsl:otherwise>
@@ -765,7 +765,7 @@
 </xsl:template>
 
 <xsl:template name="next-node">
-  <xsl:param name="self" select="/guide/@self"/>
+  <xsl:param name="self" select="/devbook/@self"/>
   <xsl:choose>
     <!-- To find the "next" node:
          * See if this node includes any subnodes... if it does, that is
@@ -775,8 +775,8 @@
          * Repeat recursively, going down parents if needed.
          * End at the root item if needed.
     -->
-    <xsl:when test="count(/guide/include) &gt; 0">
-      <xsl:value-of select="/guide/include[1]/@href"/>
+    <xsl:when test="count(/devbook/include) &gt; 0">
+      <xsl:value-of select="/devbook/include[1]/@href"/>
     </xsl:when>
     <xsl:when test="$self != ''">
       <!-- Turn the absolute path into a relative path so we can find ourselves
@@ -785,7 +785,7 @@
       <xsl:variable name="parent" select="substring($self, 1, string-length($self) - string-length($path_self))"/>
       <!-- Go down a parent, lookup the item after us... -->
       <xsl:variable name="following" select="document(concat($parent, 'text.xml'))
-                                             /guide/include[@href=$path_self]/following-sibling::include[1]"/>
+                                             /devbook/include[@href=$path_self]/following-sibling::include[1]"/>
       <xsl:text>../</xsl:text>
       <xsl:choose>
         <!-- If we have an item after us, we need not recurse any further... -->
@@ -806,7 +806,7 @@
   <!-- This function recurses forward down nodes stopping at the very last include... -->
   <xsl:param name="root"/>
   <xsl:param name="path"/>
-  <xsl:variable name="include" select="document(concat($root, $path, 'text.xml'))/guide/include[last()]/@href"/>
+  <xsl:variable name="include" select="document(concat($root, $path, 'text.xml'))/devbook/include[last()]/@href"/>
   <xsl:choose>
     <xsl:when test="$include">
       <xsl:call-template name="getLastNode">
@@ -821,7 +821,7 @@
 </xsl:template>
 
 <xsl:template name="previous-node">
-  <xsl:variable name="self" select="/guide/@self"/>
+  <xsl:variable name="self" select="/devbook/@self"/>
   <xsl:if test="$self != ''">
     <!-- To find the "previous" node:
          * Go down to our parent
@@ -836,7 +836,7 @@
     <!-- Note that index 1 refers to the immediately preceding sibling looking
          back from the context node, not the first sibling in document order. -->
     <xsl:variable name="preceding" select="document(concat($parent, 'text.xml'))
-                                           /guide/include[@href=$path_self]/preceding-sibling::include[1]"/>
+                                           /devbook/include[@href=$path_self]/preceding-sibling::include[1]"/>
     <xsl:text>../</xsl:text>
     <xsl:if test="$preceding">
       <xsl:call-template name="getLastNode">
@@ -853,7 +853,7 @@
   </xsl:variable>
   <a class="w-250 text-center" href="{concat($next, 'index.html')}">
     <span class="truncated-text d-inline-block max-w-200 mr-2">
-      <xsl:value-of select="document(concat(/guide/@self, $next, 'text.xml'))/guide/chapter[1]/title"/>
+      <xsl:value-of select="document(concat(/devbook/@self, $next, 'text.xml'))/devbook/chapter[1]/title"/>
     </span>
     <span class="fa fa-arrow-right"/>
   </a>
@@ -872,13 +872,13 @@
   <a class="w-250 text-center" href="{$link}">
     <span class="fa fa-arrow-left"/>
     <span class="truncated-text d-inline-block max-w-200 ml-2">
-      <xsl:value-of select="document(concat(/guide/@self, $previous, 'text.xml'))/guide/chapter[1]/title"/>
+      <xsl:value-of select="document(concat(/devbook/@self, $previous, 'text.xml'))/devbook/chapter[1]/title"/>
     </span>
   </a>
 </xsl:template>
 
 <xsl:template name="printParentDocs">
-  <xsl:param name="depth" select="string-length(/guide/@self) - string-length(translate(/guide/@self, '/', ''))"/>
+  <xsl:param name="depth" select="string-length(/devbook/@self) - string-length(translate(/devbook/@self, '/', ''))"/>
   <xsl:choose>
     <xsl:when test="$depth &gt; 0">
       <xsl:variable name="relative_path_depth_recursion">
@@ -889,7 +889,8 @@
       </xsl:variable>
       <li>
         <a href="{$relative_path_depth_recursion}index.html">
-          <xsl:value-of select="document(concat(/guide/@self, $relative_path_depth_recursion, 'text.xml'))/guide/chapter[1]/title"/>
+          <xsl:value-of select="document(concat(/devbook/@self, $relative_path_depth_recursion, 'text.xml'))
+                                /devbook/chapter[1]/title"/>
         </a>
       </li>
       <xsl:call-template name="printParentDocs">

--- a/devbook.xsl
+++ b/devbook.xsl
@@ -429,7 +429,7 @@
 </xsl:template>
 
 <!-- TOC Tree -->
-<xsl:template match="contentsTree" name="contentsTree">
+<xsl:template match="contents" name="contents">
   <xsl:param name="depth" select="0"/>
   <xsl:param name="maxdepth">
     <xsl:choose>
@@ -463,7 +463,7 @@
         <xsl:for-each select="document($doc_self)/devbook/include">
           <count value="{count(document(concat($path, @href, 'text.xml'))//*[name()=$extraction])}"
                  path="{concat($path, @href)}">
-            <xsl:call-template name="contentsTree">
+            <xsl:call-template name="contents">
               <xsl:with-param name="depth" select="$depth + 1"/>
               <xsl:with-param name="maxdepth" select="$maxdepth"/>
               <xsl:with-param name="path" select="concat($path, @href)"/>
@@ -479,7 +479,7 @@
         <ul>
           <xsl:for-each select="document($doc_self)/devbook/include">
             <xsl:variable name="extraction_counter_node">
-              <xsl:call-template name="contentsTree">
+              <xsl:call-template name="contents">
                 <xsl:with-param name="depth" select="$depth + 1"/>
                 <xsl:with-param name="maxdepth" select="$maxdepth"/>
                 <xsl:with-param name="path" select="concat($path, @href)"/>
@@ -513,7 +513,7 @@
                     </xsl:for-each>
                   </ul>
                 </xsl:if>
-                <xsl:call-template name="contentsTree">
+                <xsl:call-template name="contents">
                   <xsl:with-param name="depth" select="$depth + 1"/>
                   <xsl:with-param name="maxdepth" select="$maxdepth"/>
                   <xsl:with-param name="path" select="concat($path, @href)"/>
@@ -637,11 +637,11 @@
                             <xsl:if test="/devbook/include">
                               <li class="divider"><xsl:comment/></li>
                               <!-- List any sub-documents included at first level.
-                                   We cannot call "contentsTree" directly, because it would
+                                   We cannot call "contents" directly, because it would
                                    insert another "ul" element. So, assign it to a variable,
                                    then copy only the "li" nodes. -->
                               <xsl:variable name="contents">
-                                <xsl:call-template name="contentsTree">
+                                <xsl:call-template name="contents">
                                   <xsl:with-param name="maxdepth" select="1"/>
                                 </xsl:call-template>
                               </xsl:variable>

--- a/ebuild-maintenance/git/text.xml
+++ b/ebuild-maintenance/git/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-maintenance/git/">
+<devbook self="ebuild-maintenance/git/">
 <chapter>
 <title>Git for Gentoo developers</title>
 <body>
@@ -314,4 +314,4 @@ Signed-off-by: Alice Bar &lt;a.bar@example.org&gt;
 </subsection>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-maintenance/new-ebuild/text.xml
+++ b/ebuild-maintenance/new-ebuild/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-maintenance/new-ebuild/">
+<devbook self="ebuild-maintenance/new-ebuild/">
 <chapter>
 <title>Adding a new ebuild</title>
 
@@ -130,4 +130,4 @@ which is often more convenient.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-maintenance/package-moves/text.xml
+++ b/ebuild-maintenance/package-moves/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-maintenance/package-moves/">
+<devbook self="ebuild-maintenance/package-moves/">
 <chapter>
 <title>Package and slot moves</title>
 <body>
@@ -162,4 +162,4 @@ way. This involves the following steps:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-maintenance/removal/text.xml
+++ b/ebuild-maintenance/removal/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-maintenance/removal/">
+<devbook self="ebuild-maintenance/removal/">
 <chapter>
 <title>Removing ebuilds and packages</title>
 
@@ -127,4 +127,4 @@ In order to remove a virtual package, follow the following procedure:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-maintenance/text.xml
+++ b/ebuild-maintenance/text.xml
@@ -15,7 +15,7 @@ familiar with.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/ebuild-maintenance/text.xml
+++ b/ebuild-maintenance/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-maintenance/">
+<devbook self="ebuild-maintenance/">
 <chapter>
 <title>Ebuild maintenance</title>
 <body>
@@ -24,4 +24,4 @@ familiar with.
 <include href="git/"/>
 <include href="package-moves/"/>
 <include href="removal/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/common-mistakes/text.xml
+++ b/ebuild-writing/common-mistakes/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/common-mistakes/">
+<devbook self="ebuild-writing/common-mistakes/">
 <chapter>
 <title>Common mistakes</title>
 
@@ -631,4 +631,4 @@ installs properly.
 
 </chapter>
 
-</guide>
+</devbook>

--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/eapi/">
+<devbook self="ebuild-writing/eapi/">
 <chapter>
 <title>EAPI usage and description</title>
 <body>
@@ -1431,4 +1431,4 @@ $(usev foo --enable-foo)
 </subsection>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/error-handling/text.xml
+++ b/ebuild-writing/error-handling/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/error-handling/">
+<devbook self="ebuild-writing/error-handling/">
 <chapter>
 <title>Error handling</title>
 
@@ -161,4 +161,4 @@ src_test() {
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/file-format/text.xml
+++ b/ebuild-writing/file-format/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/file-format/">
+<devbook self="ebuild-writing/file-format/">
 <chapter>
 <title>Ebuild file format</title>
 
@@ -242,4 +242,4 @@ for details.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_config/text.xml
+++ b/ebuild-writing/functions/pkg_config/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_config/">
+<devbook self="ebuild-writing/functions/pkg_config/">
 <chapter>
 <title>pkg_config</title>
 
@@ -66,4 +66,4 @@ pkg_config() {
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_info/text.xml
+++ b/ebuild-writing/functions/pkg_info/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_info/">
+<devbook self="ebuild-writing/functions/pkg_info/">
 <chapter>
 <title>pkg_info</title>
 
@@ -68,4 +68,4 @@ available.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_nofetch/text.xml
+++ b/ebuild-writing/functions/pkg_nofetch/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_nofetch/">
+<devbook self="ebuild-writing/functions/pkg_nofetch/">
 <chapter>
 <title>pkg_nofetch</title>
 
@@ -76,4 +76,4 @@ already available in the <c>distfiles</c> directory.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_postinst/text.xml
+++ b/ebuild-writing/functions/pkg_postinst/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_postinst/">
+<devbook self="ebuild-writing/functions/pkg_postinst/">
 <chapter>
 <title>pkg_postinst</title>
 
@@ -70,4 +70,4 @@ variable.</p>
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_postrm/text.xml
+++ b/ebuild-writing/functions/pkg_postrm/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_postrm/">
+<devbook self="ebuild-writing/functions/pkg_postrm/">
 <chapter>
 <title>pkg_postrm</title>
 
@@ -64,4 +64,4 @@ generated content after a package has been uninstalled.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_preinst/text.xml
+++ b/ebuild-writing/functions/pkg_preinst/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_preinst/">
+<devbook self="ebuild-writing/functions/pkg_preinst/">
 <chapter>
 <title>pkg_preinst</title>
 
@@ -80,4 +80,4 @@ There are a few things that are often done in <c>pkg_preinst</c>:
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_prerm/text.xml
+++ b/ebuild-writing/functions/pkg_prerm/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_prerm/">
+<devbook self="ebuild-writing/functions/pkg_prerm/">
 <chapter>
 <title>pkg_prerm</title>
 
@@ -62,4 +62,4 @@ a clean unmerge.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_pretend/text.xml
+++ b/ebuild-writing/functions/pkg_pretend/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_pretend/">
+<devbook self="ebuild-writing/functions/pkg_pretend/">
 <chapter>
 <title>pkg_pretend</title>
 
@@ -85,4 +85,4 @@ This phase typically checks for a kernel configuration and may
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/pkg_setup/text.xml
+++ b/ebuild-writing/functions/pkg_setup/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/pkg_setup/">
+<devbook self="ebuild-writing/functions/pkg_setup/">
 <chapter>
 <title>pkg_setup</title>
 
@@ -63,4 +63,4 @@ pkg_setup() {
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_compile/build-environment/text.xml
+++ b/ebuild-writing/functions/src_compile/build-environment/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_compile/build-environment/">
+<devbook self="ebuild-writing/functions/src_compile/build-environment/">
 <chapter>
 <title>Configuring build environment</title>
 
@@ -147,4 +147,4 @@ See <uri link="::eclass-reference/flag-o-matic.eclass/"/> for a full reference.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_compile/building/text.xml
+++ b/ebuild-writing/functions/src_compile/building/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_compile/building/">
+<devbook self="ebuild-writing/functions/src_compile/building/">
 <chapter>
 <title>Building a package</title>
 
@@ -101,4 +101,4 @@ machines with a MIPS CPU.)
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_compile/no-build-system/text.xml
+++ b/ebuild-writing/functions/src_compile/no-build-system/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_compile/no-build-system/">
+<devbook self="ebuild-writing/functions/src_compile/no-build-system/">
 <chapter>
 <title>No build system</title>
 
@@ -58,4 +58,4 @@ and send it upstream.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_compile/text.xml
+++ b/ebuild-writing/functions/src_compile/text.xml
@@ -79,7 +79,7 @@ The following subsections cover different topics which often occur when writing
 <c>src_compile</c> functions.
 </p>
 
-<contentsTree/>
+<contents/>
 </body>
 </section>
 

--- a/ebuild-writing/functions/src_compile/text.xml
+++ b/ebuild-writing/functions/src_compile/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_compile/">
+<devbook self="ebuild-writing/functions/src_compile/">
 <chapter>
 <title>src_compile</title>
 
@@ -88,4 +88,4 @@ The following subsections cover different topics which often occur when writing
 <include href="build-environment/"/>
 <include href="building/"/>
 <include href="no-build-system/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_configure/configuring/text.xml
+++ b/ebuild-writing/functions/src_configure/configuring/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_configure/configuring/">
+<devbook self="ebuild-writing/functions/src_configure/configuring/">
 <chapter>
 <title>Configuring a package</title>
 
@@ -126,4 +126,4 @@ In EAPI 7 and later, the following option is passed in addition:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_configure/text.xml
+++ b/ebuild-writing/functions/src_configure/text.xml
@@ -78,7 +78,7 @@ The following subsections cover different topics which often occur when writing
 <c>src_configure</c> functions.
 </p>
 
-<contentsTree/>
+<contents/>
 </body>
 </section>
 

--- a/ebuild-writing/functions/src_configure/text.xml
+++ b/ebuild-writing/functions/src_configure/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_configure/">
+<devbook self="ebuild-writing/functions/src_configure/">
 <chapter>
 <title>src_configure</title>
 
@@ -85,5 +85,5 @@ The following subsections cover different topics which often occur when writing
 </chapter>
 
 <include href="configuring/"/>
-</guide>
+</devbook>
 

--- a/ebuild-writing/functions/src_install/docompress/text.xml
+++ b/ebuild-writing/functions/src_install/docompress/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_install/docompress/">
+<devbook self="ebuild-writing/functions/src_install/docompress/">
 <chapter>
 <title>Controllable compression</title>
 <body>
@@ -48,4 +48,4 @@ it will be ignored with a warning.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_install/text.xml
+++ b/ebuild-writing/functions/src_install/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_install/">
+<devbook self="ebuild-writing/functions/src_install/">
 <chapter>
 <title>src_install</title>
 
@@ -236,4 +236,4 @@ The following subsections cover different topics which often occur when writing
 </chapter>
 
 <include href="docompress/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_install/text.xml
+++ b/ebuild-writing/functions/src_install/text.xml
@@ -229,7 +229,7 @@ The following subsections cover different topics which often occur when writing
 <c>src_install</c> functions.
 </p>
 
-<contentsTree/>
+<contents/>
 
 </body>
 </section>

--- a/ebuild-writing/functions/src_prepare/autopackage/text.xml
+++ b/ebuild-writing/functions/src_prepare/autopackage/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_prepare/autopackage/">
+<devbook self="ebuild-writing/functions/src_prepare/autopackage/">
 <chapter>
 <title>Autopackage</title>
 
@@ -39,4 +39,4 @@ indeed, they pass off some of their most broken behaviour as
 </p>
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_prepare/eapply/text.xml
+++ b/ebuild-writing/functions/src_prepare/eapply/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_prepare/eapply/">
+<devbook self="ebuild-writing/functions/src_prepare/eapply/">
 <chapter>
 <title>Patching with eapply</title>
 <body>
@@ -133,4 +133,4 @@ src_prepare() {
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_prepare/text.xml
+++ b/ebuild-writing/functions/src_prepare/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_prepare/">
+<devbook self="ebuild-writing/functions/src_prepare/">
 <chapter>
 <title>src_prepare</title>
 
@@ -97,4 +97,4 @@ when writing <c>src_prepare</c> functions.
 </chapter>
 <include href="eapply/"/>
 <include href="autopackage/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_prepare/text.xml
+++ b/ebuild-writing/functions/src_prepare/text.xml
@@ -90,7 +90,7 @@ The following subsections cover different topics which often occur
 when writing <c>src_prepare</c> functions.
 </p>
 
-<contentsTree/>
+<contents/>
 </body>
 </section>
 

--- a/ebuild-writing/functions/src_test/text.xml
+++ b/ebuild-writing/functions/src_test/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_test/">
+<devbook self="ebuild-writing/functions/src_test/">
 <chapter>
 <title>src_test</title>
 
@@ -274,4 +274,4 @@ src_test() {
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_unpack/other-formats/text.xml
+++ b/ebuild-writing/functions/src_unpack/other-formats/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_unpack/other-formats/">
+<devbook self="ebuild-writing/functions/src_unpack/other-formats/">
 <chapter>
 <title>Other archive formats</title>
 
@@ -50,4 +50,4 @@ done a release in at least ten years.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_unpack/rpm-sources/">
+<devbook self="ebuild-writing/functions/src_unpack/rpm-sources/">
 <chapter>
 <title>RPM sources</title>
 
@@ -97,4 +97,4 @@ src_prepare() {
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_unpack/text.xml
+++ b/ebuild-writing/functions/src_unpack/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_unpack/">
+<devbook self="ebuild-writing/functions/src_unpack/">
 <chapter>
 <title>src_unpack</title>
 
@@ -125,4 +125,4 @@ The following subsections cover different topics which often occur when writing
 <include href="vcs-sources/"/>
 <include href="rpm-sources/"/>
 <include href="other-formats/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/src_unpack/text.xml
+++ b/ebuild-writing/functions/src_unpack/text.xml
@@ -116,7 +116,7 @@ The following subsections cover different topics which often occur when writing
 <c>src_unpack</c> functions.
 </p>
 
-<contentsTree/>
+<contents/>
 </body>
 </section>
 

--- a/ebuild-writing/functions/src_unpack/vcs-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/vcs-sources/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/src_unpack/vcs-sources/">
+<devbook self="ebuild-writing/functions/src_unpack/vcs-sources/">
 <chapter>
 <title>Version Control System (VCS) sources</title>
 <body>
@@ -97,4 +97,4 @@ date or revision are even worse candidates for tree inclusion:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/text.xml
+++ b/ebuild-writing/functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/functions/">
+<devbook self="ebuild-writing/functions/">
 <chapter>
 <title>Ebuild phase functions</title>
 
@@ -129,4 +129,4 @@ during the <c>src_compile</c> phase is equivalent to a call to the
 <include href="pkg_postrm/"/>
 <include href="pkg_config/"/>
 <include href="pkg_info/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/functions/text.xml
+++ b/ebuild-writing/functions/text.xml
@@ -109,7 +109,7 @@ during the <c>src_compile</c> phase is equivalent to a call to the
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/ebuild-writing/messages/text.xml
+++ b/ebuild-writing/messages/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/messages/">
+<devbook self="ebuild-writing/messages/">
 <chapter>
 <title>Messages</title>
 
@@ -160,4 +160,4 @@ eqawarn "frozbinate eclass for instructions on how to convert."
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/misc-files/metadata/text.xml
+++ b/ebuild-writing/misc-files/metadata/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/misc-files/metadata/">
+<devbook self="ebuild-writing/misc-files/metadata/">
 <chapter>
 <title>Package and category <c>metadata.xml</c></title>
 
@@ -735,4 +735,4 @@ Date:   Tue Sep 22 10:47:49 2015 +0200
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/misc-files/patches/text.xml
+++ b/ebuild-writing/misc-files/patches/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/misc-files/patches/">
+<devbook self="ebuild-writing/misc-files/patches/">
 <chapter>
 <title>Patches</title>
 
@@ -456,4 +456,4 @@ https://bugs.gentoo.org/226035
 </subsection>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/misc-files/text.xml
+++ b/ebuild-writing/misc-files/text.xml
@@ -12,7 +12,7 @@ This section contains some notes on various miscellaneous files.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/ebuild-writing/misc-files/text.xml
+++ b/ebuild-writing/misc-files/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/misc-files/">
+<devbook self="ebuild-writing/misc-files/">
 <chapter>
 <title>Miscellaneous files</title>
 
@@ -19,4 +19,4 @@ This section contains some notes on various miscellaneous files.
 
 <include href="metadata/"/>
 <include href="patches/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/text.xml
+++ b/ebuild-writing/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/">
+<devbook self="ebuild-writing/">
 <chapter>
 <title>Ebuild writing</title>
 
@@ -31,4 +31,4 @@ with some general notes and extended examples.
 <include href="misc-files/"/>
 <include href="user-submitted/"/>
 <include href="common-mistakes/"/>
-</guide>
+</devbook>

--- a/ebuild-writing/text.xml
+++ b/ebuild-writing/text.xml
@@ -14,7 +14,7 @@ with some general notes and extended examples.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/ebuild-writing/use-conditional-code/text.xml
+++ b/ebuild-writing/use-conditional-code/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/use-conditional-code/">
+<devbook self="ebuild-writing/use-conditional-code/">
 <chapter>
 <title>USE flag conditional code</title>
 
@@ -61,4 +61,4 @@ use it in new code.
 </body>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/user-submitted/text.xml
+++ b/ebuild-writing/user-submitted/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/user-submitted/">
+<devbook self="ebuild-writing/user-submitted/">
 <chapter>
 <title>User-submitted ebuilds</title>
 
@@ -64,4 +64,4 @@ of encouragement and support and continue to improve in their abilities.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/users-and-groups/text.xml
+++ b/ebuild-writing/users-and-groups/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/users-and-groups/">
+<devbook self="ebuild-writing/users-and-groups/">
 <chapter>
 <title>Users and groups</title>
 
@@ -323,4 +323,4 @@ DEPEND="${RDEPEND}"
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/using-eclasses/">
+<devbook self="ebuild-writing/using-eclasses/">
 <chapter>
 <title>Using eclasses</title>
 
@@ -98,4 +98,4 @@ to handle the bash completion file via <c>dobashcomp</c>.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="ebuild-writing/variables/">
+<devbook self="ebuild-writing/variables/">
 <chapter>
 <title>Variables</title>
 
@@ -1085,4 +1085,4 @@ rule, as it is intended to be passed to the compiler driver rather than
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="eclass-writing/">
+<devbook self="eclass-writing/">
 <chapter>
 <title>Eclass writing guide</title>
 <body>
@@ -842,4 +842,4 @@ EXPORT_FUNCTIONS src_configure src_compile
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/function-reference/build-functions/text.xml
+++ b/function-reference/build-functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/build-functions/">
+<devbook self="function-reference/build-functions/">
 <chapter>
 <title>Build functions reference</title>
 
@@ -50,4 +50,4 @@ during the unpack and compile stages.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/function-reference/error-functions/text.xml
+++ b/function-reference/error-functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/error-functions/">
+<devbook self="function-reference/error-functions/">
 <chapter>
 <title>Error functions reference</title>
 <body>
@@ -47,4 +47,4 @@ The following functions are provided by the package manager for error handling.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/function-reference/install-functions/text.xml
+++ b/function-reference/install-functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/install-functions/">
+<devbook self="function-reference/install-functions/">
 <chapter>
 <title>Install functions reference</title>
 <body>
@@ -443,4 +443,4 @@ The <c>*into</c> functions create the directory if it does not already exist.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/function-reference/message-functions/text.xml
+++ b/function-reference/message-functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/message-functions/">
+<devbook self="function-reference/message-functions/">
 <chapter>
 <title>Message functions reference</title>
 <body>
@@ -91,4 +91,4 @@ See <uri link="::ebuild-writing/messages/"/> for a detailed discussion.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/function-reference/query-functions/text.xml
+++ b/function-reference/query-functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/query-functions/">
+<devbook self="function-reference/query-functions/">
 <chapter>
 <title>Query functions reference</title>
 <body>
@@ -145,4 +145,4 @@ query variables and similar state.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/function-reference/sandbox-functions/text.xml
+++ b/function-reference/sandbox-functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/sandbox-functions/">
+<devbook self="function-reference/sandbox-functions/">
 <chapter>
 <title>Sandbox functions reference</title>
 <body>
@@ -69,4 +69,4 @@ for how to handle sandbox-related build problems.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/function-reference/text.xml
+++ b/function-reference/text.xml
@@ -12,7 +12,7 @@ The following functions are available for use in ebuilds:
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/function-reference/text.xml
+++ b/function-reference/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/">
+<devbook self="function-reference/">
 <chapter>
 <title>Function reference</title>
 
@@ -25,4 +25,4 @@ The following functions are available for use in ebuilds:
 <include href="sandbox-functions/"/>
 <include href="version-functions/"/>
 
-</guide>
+</devbook>

--- a/function-reference/version-functions/text.xml
+++ b/function-reference/version-functions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="function-reference/version-functions/">
+<devbook self="function-reference/version-functions/">
 <chapter>
 <title>Version functions reference</title>
 <body>
@@ -216,4 +216,4 @@ If the range spans outside the version string, it is silently truncated.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/autotools/text.xml
+++ b/general-concepts/autotools/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/autotools/">
+<devbook self="general-concepts/autotools/">
 <chapter>
 <title>The basics of Autotools</title>
 
@@ -694,4 +694,4 @@ For more details on autotools:
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/config-protect/text.xml
+++ b/general-concepts/config-protect/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/config-protect/">
+<devbook self="general-concepts/config-protect/">
 <chapter>
 <title>Configuration file protection</title>
 <body>
@@ -43,4 +43,4 @@ needing to call <c>etc-update</c> after the package is merged:
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/copyright-policy/text.xml
+++ b/general-concepts/copyright-policy/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/copyright-policy/">
+<devbook self="general-concepts/copyright-policy/">
 <chapter>
 <title>Copyright policy</title>
 <body>
@@ -144,4 +144,4 @@ When can a contribution be accepted?
 
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/dependencies/">
+<devbook self="general-concepts/dependencies/">
 <chapter>
 <title>Dependencies</title>
 <body>
@@ -849,4 +849,4 @@ USE flags. This would then break building your ebuild.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/ebuild-revisions/">
+<devbook self="general-concepts/ebuild-revisions/">
 <chapter>
 <title>Ebuild revisions</title>
 
@@ -132,5 +132,5 @@ of thumb could be used as a guideline:
 
 </body>
 </chapter>
-</guide>
+</devbook>
 

--- a/general-concepts/emerge-and-ebuild/text.xml
+++ b/general-concepts/emerge-and-ebuild/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/emerge-and-ebuild/">
+<devbook self="general-concepts/emerge-and-ebuild/">
 <chapter>
 <title>Emerge and ebuild relationships</title>
 
@@ -18,5 +18,5 @@ and any eclasses. The <c>${D}</c> to <c>${ROOT}</c> install is handled by <c>eme
 
 </body>
 </chapter>
-</guide>
+</devbook>
 

--- a/general-concepts/filesystem/text.xml
+++ b/general-concepts/filesystem/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/filesystem/">
+<devbook self="general-concepts/filesystem/">
 <chapter>
 <title>Filesystem</title>
 
@@ -81,4 +81,4 @@ much of our policy coincides with it.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/git-to-rsync/text.xml
+++ b/general-concepts/git-to-rsync/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/git-to-rsync/">
+<devbook self="general-concepts/git-to-rsync/">
 <chapter>
 <title>Git to RSYNC</title>
 
@@ -38,4 +38,4 @@
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/install-destinations/text.xml
+++ b/general-concepts/install-destinations/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/install-destinations/">
+<devbook self="general-concepts/install-destinations/">
 <chapter>
 <title>Install destinations</title>
 
@@ -28,5 +28,5 @@ When inside <c>pkg_preinst</c>, the image to be installed can be accessed under
 
 </body>
 </chapter>
-</guide>
+</devbook>
 

--- a/general-concepts/licenses/text.xml
+++ b/general-concepts/licenses/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/licenses/">
+<devbook self="general-concepts/licenses/">
 <chapter>
 <title>Licenses</title>
 
@@ -286,4 +286,4 @@ on copyright and licensing:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/mailing-lists/text.xml
+++ b/general-concepts/mailing-lists/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/mailing-lists/">
+<devbook self="general-concepts/mailing-lists/">
 <chapter>
 <title>Mailing lists</title>
 <body>
@@ -77,4 +77,4 @@ subscribed to it.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/manifest/text.xml
+++ b/general-concepts/manifest/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/manifest/">
+<devbook self="general-concepts/manifest/">
 <chapter>
 <title>Manifest</title>
 
@@ -77,4 +77,4 @@ mirrors</uri>.
 </subsection>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/mirrors/text.xml
+++ b/general-concepts/mirrors/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/mirrors/">
+<devbook self="general-concepts/mirrors/">
 <chapter>
 <title>Mirrors</title>
 
@@ -149,4 +149,4 @@ Not doing so can cause all kinds of problems with strict firewalls.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/news/text.xml
+++ b/general-concepts/news/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/news/">
+<devbook self="general-concepts/news/">
 <chapter>
 <title>News items</title>
 
@@ -60,4 +60,4 @@ man page.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/overlay/text.xml
+++ b/general-concepts/overlay/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/overlay/">
+<devbook self="general-concepts/overlay/">
 <chapter>
 <title>Overlay</title>
 
@@ -51,4 +51,4 @@ eclasses.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/package-collisions/text.xml
+++ b/general-concepts/package-collisions/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/package-collisions/">
+<devbook self="general-concepts/package-collisions/">
 <chapter>
 <title>Package collisions</title>
 <body>
@@ -46,4 +46,4 @@ won't overwrite them).
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/package-maintainers/text.xml
+++ b/general-concepts/package-maintainers/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/package-maintainers/">
+<devbook self="general-concepts/package-maintainers/">
 <chapter>
 <title>Package maintainers</title>
 <body>
@@ -89,4 +89,4 @@ providing a list of newly-unmaintained packages.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/pic/text.xml
+++ b/general-concepts/pic/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/pic/">
+<devbook self="general-concepts/pic/">
 <chapter>
 <title>Position Independent Code</title>
 <body>
@@ -22,4 +22,4 @@ developer forum (like the <c>gentoo-dev</c> mailing list or the
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/portage-cache/text.xml
+++ b/general-concepts/portage-cache/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/portage-cache/">
+<devbook self="general-concepts/portage-cache/">
 <chapter>
 <title>The Portage cache</title>
 
@@ -85,4 +85,4 @@ regular and live packages.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/projects/text.xml
+++ b/general-concepts/projects/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/projects/">
+<devbook self="general-concepts/projects/">
 <chapter>
 <title>Projects</title>
 <body>
@@ -93,4 +93,4 @@ the project's email address <c>devmanual@gentoo.org</c>.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/sandbox/text.xml
+++ b/general-concepts/sandbox/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/sandbox/">
+<devbook self="general-concepts/sandbox/">
 <chapter>
 <title>Sandbox</title>
 
@@ -28,4 +28,4 @@ on fixing sandbox-related build problems.
 </body>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/slotting/text.xml
+++ b/general-concepts/slotting/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/slotting/">
+<devbook self="general-concepts/slotting/">
 <chapter>
 <title>Slotting</title>
 
@@ -230,4 +230,4 @@ alphanumeric character or <c>_</c>, and contain alphanumerics and <c>_</c>,
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/text.xml
+++ b/general-concepts/text.xml
@@ -13,7 +13,7 @@ writing ebuilds or working with the Gentoo repository.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 

--- a/general-concepts/text.xml
+++ b/general-concepts/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/">
+<devbook self="general-concepts/">
 <chapter>
 <title>General concepts</title>
 
@@ -46,4 +46,4 @@ writing ebuilds or working with the Gentoo repository.
 <include href="use-flags/"/>
 <include href="user-environment/"/>
 <include href="virtuals/"/>
-</guide>
+</devbook>

--- a/general-concepts/tree/text.xml
+++ b/general-concepts/tree/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/tree/">
+<devbook self="general-concepts/tree/">
 <chapter>
 <title>The Gentoo repository</title>
 
@@ -184,4 +184,4 @@ Software-wise, in general all of the following should be met in order for a pack
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/use-flags/text.xml
+++ b/general-concepts/use-flags/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/use-flags/">
+<devbook self="general-concepts/use-flags/">
 <chapter>
 <title>USE flags</title>
 
@@ -387,4 +387,4 @@ are no <c>~arch</c> USE flags, so don't try <c>if use ~x86</c>.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/user-environment/text.xml
+++ b/general-concepts/user-environment/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/user-environment/">
+<devbook self="general-concepts/user-environment/">
 <chapter>
 <title>User environment</title>
 <body>
@@ -87,4 +87,4 @@ will automatically be merged with the user's settings. LDFLAGS also should be re
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/general-concepts/virtuals/text.xml
+++ b/general-concepts/virtuals/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="general-concepts/virtuals/">
+<devbook self="general-concepts/virtuals/">
 <chapter>
 <title>Virtuals</title>
 
@@ -155,4 +155,4 @@ is not viable if a clean choice between the two providers is desired.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/hosted-projects/text.xml
+++ b/hosted-projects/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="hosted-projects/">
+<devbook self="hosted-projects/">
 <chapter>
 <title>Hosted projects</title>
 
@@ -163,4 +163,4 @@ Good places to look for further hints include:
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/keywording/text.xml
+++ b/keywording/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="keywording/">
+<devbook self="keywording/">
 <chapter>
 <title>Keywording and stabilization</title>
 <body>
@@ -525,4 +525,4 @@ so that you can tidy up, file a bug.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/profiles/categories/text.xml
+++ b/profiles/categories/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/categories/">
+<devbook self="profiles/categories/">
 <chapter>
 <title>Profiles <c>categories</c> file</title>
 
@@ -21,4 +21,4 @@ link="::ebuild-writing/misc-files/metadata/#Category metadata"/>.
 </body>
 
 </chapter>
-</guide>
+</devbook>

--- a/profiles/info_files/text.xml
+++ b/profiles/info_files/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/info_files/">
+<devbook self="profiles/info_files/">
 <chapter>
 <title>Profiles <c>info_</c> files</title>
 <body>
@@ -13,5 +13,5 @@ the <c>gentoo-dev</c> mailing list.
 
 </body>
 </chapter>
-</guide>
+</devbook>
 

--- a/profiles/make.defaults/text.xml
+++ b/profiles/make.defaults/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/make.defaults/">
+<devbook self="profiles/make.defaults/">
 <chapter>
 <title>Profiles <c>make.defaults</c> file</title>
 <body>
@@ -20,4 +20,4 @@ relevant arch team, or <c>gentoo-dev</c> for high-up <c>make.defaults</c> files.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/profiles/package.mask/text.xml
+++ b/profiles/package.mask/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/package.mask/">
+<devbook self="profiles/package.mask/">
 <chapter>
 <title>Profiles <c>package.mask</c> file</title>
 <body>
@@ -45,4 +45,4 @@ This file can be used in subprofiles to mask packages only for certain setups.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/profiles/packages/text.xml
+++ b/profiles/packages/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/packages/">
+<devbook self="profiles/packages/">
 <chapter>
 <title>Profiles <c>packages</c> file</title>
 <body>
@@ -22,4 +22,4 @@ outcome), then the entry in <c>packages</c> must be accompanied by a correspondi
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/profiles/text.xml
+++ b/profiles/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/">
+<devbook self="profiles/">
 <chapter>
 <title>Profiles</title>
 
@@ -33,4 +33,4 @@ Portage-specific behaviour must not be relied upon in the repository.
 <include href="use.desc/"/>
 <include href="use.mask/"/>
 
-</guide>
+</devbook>

--- a/profiles/text.xml
+++ b/profiles/text.xml
@@ -19,7 +19,7 @@ Portage-specific behaviour must not be relied upon in the repository.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/profiles/updates/text.xml
+++ b/profiles/updates/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/updates/">
+<devbook self="profiles/updates/">
 <chapter>
 <title>Profiles <c>updates/</c> directory</title>
 <body>
@@ -47,4 +47,4 @@ the actual changes to the package have to be done manually.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/profiles/use.desc/text.xml
+++ b/profiles/use.desc/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/use.desc/">
+<devbook self="profiles/use.desc/">
 <chapter>
 <title>Profiles <c>use.desc</c> and <c>use.local.desc</c> files</title>
 <body>
@@ -40,4 +40,4 @@ listed.</p>
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/profiles/use.mask/text.xml
+++ b/profiles/use.mask/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="profiles/use.mask/">
+<devbook self="profiles/use.mask/">
 <chapter>
 <title>Profiles <c>use.mask</c> file</title>
 <body>
@@ -43,5 +43,5 @@ See <uri link="::general-concepts/use-flags/#noblah USE flags"/> for more discus
 
 </body>
 </chapter>
-</guide>
+</devbook>
 

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="quickstart/">
+<devbook self="quickstart/">
 <chapter>
 <title>Quickstart ebuild guide</title>
 
@@ -428,4 +428,4 @@ match the <c>./configure</c> argument.
 </section>
 
 </chapter>
-</guide>
+</devbook>

--- a/tasks-reference/completion/text.xml
+++ b/tasks-reference/completion/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tasks-reference/completion/">
+<devbook self="tasks-reference/completion/">
 <chapter>
 <title>Completion files</title>
 <body>
@@ -425,4 +425,4 @@ Lines 1-12 are pretty much the same as in the previous section.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/tasks-reference/environment/text.xml
+++ b/tasks-reference/environment/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tasks-reference/environment/">
+<devbook self="tasks-reference/environment/">
 <chapter>
 <title>Environment files</title>
 
@@ -29,4 +29,4 @@ Environment Variables section</uri>.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tasks-reference/init-scripts/text.xml
+++ b/tasks-reference/init-scripts/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tasks-reference/init-scripts/">
+<devbook self="tasks-reference/init-scripts/">
 <chapter>
 <title>Init scripts</title>
 
@@ -29,4 +29,4 @@ OpenRC documentation</uri>.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tasks-reference/pam/text.xml
+++ b/tasks-reference/pam/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tasks-reference/pam/">
+<devbook self="tasks-reference/pam/">
 <chapter>
 <title>Working with PAM</title>
 <body>
@@ -237,4 +237,4 @@ right directory.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/tasks-reference/text.xml
+++ b/tasks-reference/text.xml
@@ -13,7 +13,7 @@ ebuilds.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/tasks-reference/text.xml
+++ b/tasks-reference/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tasks-reference/">
+<devbook self="tasks-reference/">
 <chapter>
 <title>Tasks reference</title>
 
@@ -22,4 +22,4 @@ ebuilds.
 <include href="environment/"/>
 <include href="init-scripts/"/>
 <include href="pam/"/>
-</guide>
+</devbook>

--- a/text.xml
+++ b/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide root="true">
+<devbook root="true">
 <chapter>
 <title>Master index</title>
 
@@ -51,4 +51,4 @@ section lists specific contributions to this manual.
 <include href="hosted-projects/"/>
 <include href="archs/"/>
 <include href="appendices/"/>
-</guide>
+</devbook>

--- a/text.xml
+++ b/text.xml
@@ -25,14 +25,14 @@ section lists specific contributions to this manual.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree maxdepth="1"/>
+<contents maxdepth="1"/>
 </body>
 </section>
 
 <section>
 <title>Full contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/tools-reference/bash/text.xml
+++ b/tools-reference/bash/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/bash/">
+<devbook self="tools-reference/bash/">
 <chapter>
 <title><c>bash</c> — standard shell</title>
 <body>
@@ -833,4 +833,4 @@ There is no <c>**=</c> assignment operator.
 </subsection>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/cat/text.xml
+++ b/tools-reference/cat/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/cat/">
+<devbook self="tools-reference/cat/">
 <chapter>
 <title><c>cat</c> — file concatenation</title>
 <body>
@@ -82,4 +82,4 @@ desired effect.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/cut/text.xml
+++ b/tools-reference/cut/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/cut/">
+<devbook self="tools-reference/cut/">
 <chapter>
 <title><c>cut</c> — column concatenation</title>
 <body>
@@ -63,4 +63,4 @@ IEEE Std 1003.1-2017-cut</uri> for full documentation.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/diff-and-patch/text.xml
+++ b/tools-reference/diff-and-patch/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/diff-and-patch/">
+<devbook self="tools-reference/diff-and-patch/">
 <chapter>
 <title><c>diff</c> and <c>patch</c> — file differences</title>
 <body>
@@ -48,4 +48,4 @@ The <c>diff(1)</c> and <c>patch(1)</c> manual pages provide more information.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/echo/text.xml
+++ b/tools-reference/echo/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/echo/">
+<devbook self="tools-reference/echo/">
 <chapter>
 <title><c>echo</c> — print strings</title>
 <body>
@@ -91,4 +91,4 @@ command are available in the <c>bash(1)</c> man page.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/ekeyword/text.xml
+++ b/tools-reference/ekeyword/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/ekeyword/">
+<devbook self="tools-reference/ekeyword/">
 <chapter>
 <title><c>ekeyword</c> — keywording</title>
 <body>
@@ -19,4 +19,4 @@ for details.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/false-and-true/text.xml
+++ b/tools-reference/false-and-true/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/false-and-true/">
+<devbook self="tools-reference/false-and-true/">
 <chapter>
 <title><c>false</c> and <c>true</c> — generating return codes</title>
 <body>
@@ -11,4 +11,4 @@ code. The <c>true</c> utility always produces a zero exit code.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/find/text.xml
+++ b/tools-reference/find/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/find/">
+<devbook self="tools-reference/find/">
 <chapter>
 <title><c>find</c> — finding files</title>
 <body>
@@ -214,4 +214,4 @@ IEEE Std 1003.1-2017-find</uri> for further details and examples.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/grep/text.xml
+++ b/tools-reference/grep/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/grep/">
+<devbook self="tools-reference/grep/">
 <chapter>
 <title><c>grep</c> — text filtering</title>
 <body>
@@ -60,4 +60,4 @@ GNU systems documents many non-portable additional features.
 
 </body>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/head-and-tail/text.xml
+++ b/tools-reference/head-and-tail/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/head-and-tail/">
+<devbook self="tools-reference/head-and-tail/">
 <chapter>
 <title><c>head</c> and <c>tail</c> — line extraction</title>
 <body>
@@ -109,4 +109,4 @@ sed -n -e '123p'
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/sed/text.xml
+++ b/tools-reference/sed/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/sed/">
+<devbook self="tools-reference/sed/">
 <chapter>
 <title>sed — stream editor</title>
 <body>
@@ -905,4 +905,4 @@ symbols.
 </body>
 </section>
 </chapter>
-</guide>
+</devbook>

--- a/tools-reference/sort/text.xml
+++ b/tools-reference/sort/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/sort/">
+<devbook self="tools-reference/sort/">
 <chapter>
 <title>sort — sorting text</title>
 <body>
@@ -23,5 +23,5 @@ IEEE Std 1003.1-2017-sort</uri> for details.
 
 </body>
 </chapter>
-</guide>
+</devbook>
 

--- a/tools-reference/text.xml
+++ b/tools-reference/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/">
+<devbook self="tools-reference/">
 <chapter>
 <title>Tools reference</title>
 
@@ -42,4 +42,4 @@ when using these tools in ebuilds.
 <!--
 <include href="xargs/"/>-->
 
-</guide>
+</devbook>

--- a/tools-reference/text.xml
+++ b/tools-reference/text.xml
@@ -20,7 +20,7 @@ when using these tools in ebuilds.
 <section>
 <title>Contents</title>
 <body>
-<contentsTree/>
+<contents/>
 </body>
 </section>
 </chapter>

--- a/tools-reference/tr/text.xml
+++ b/tools-reference/tr/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/tr/">
+<devbook self="tools-reference/tr/">
 <chapter>
 <title>tr — character translation</title>
 <body>
@@ -52,5 +52,5 @@ documentation for a full list.
 
 </body>
 </chapter>
-</guide>
+</devbook>
 

--- a/tools-reference/uniq/text.xml
+++ b/tools-reference/uniq/text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<guide self="tools-reference/uniq/">
+<devbook self="tools-reference/uniq/">
 <chapter>
 <title>uniq — filtering duplicates</title>
 <body>
@@ -21,4 +21,4 @@ IEEE Std 1003.1-2017-uniq</uri> for details.
 
 </body>
 </chapter>
-</guide>
+</devbook>


### PR DESCRIPTION
This has bugged me since quite some time, mainly because nXML mode in Emacs (or rather, `rng-loc`) locates the schema based on the XML document element. So, when looking at old documentation, it would see `<guide>`, load `devbook.rnc`, and would end up highlighting supposedly bad syntax.

Renaming the document element to `devbook` will avoid these problems, because `guide` can then be dropped from nXML mode's schema locating, and the vacuous schema will be used for GuideXML documents (which is not a problem when looking at them).

While at it, rename `<contentsTree/>` to `<contents/>` because it is the only element whose name is in camelCase. (No strong opinion about the name here, `contents` is what is used by Texinfo. So please speak up if you prefer `tableofcontents` (as in LaTeX), `toc` (as in Mediawiki), or even `childlist` (used in the old RST Devmanual).)

Timeline: If there are no objections, I would start with a transitional release of `app-emacs/nxml-gentoo-schemas` that would accept both the old `guide` and the new `devbook` element. The Devmanual would be updated some time after stabilisation of that version.
