### PR TITLE
general-concepts/use-flags: hint towards CMAKE_DISABLE_FIND_PACKAGE_<pkg>

### DIFF
--- a/general-concepts/use-flags/text.xml
+++ b/general-concepts/use-flags/text.xml
@@ -32,9 +32,10 @@ Automagic dependencies are preferably fixed by preparing a build system patch
 adding appropriate options to control the dependency in question, and submitting
 this patch upstream for the benefit of all users. To avoid carrying additional
 patches downstream, automagic dependencies can usually be worked around using
-special build system options (e.g. cache variables in autotools) or through
-depending on the relevant packages unconditionally (i.e. forcing the check
-to always succeed).
+special build system options (e.g. cache variables in autotools or
+<c><uri link="https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html">
+CMAKE_DISABLE_FIND_PACKAGE_FOO=$(usex !foo)</uri></c>) or through depending on
+the relevant packages unconditionally (i.e. forcing the check to always succeed).
 </p>
 
 <note>


### PR DESCRIPTION
Motivated by https://github.com/gentoo/gentoo/pull/39625/files/9eb2f7bf5087777458cfc8838e43cdc533507d5b#r1874576245