### PR TITLE
Pair emake -j1 with --shuffle=none

### DIFF
--- a/ebuild-writing/functions/src_compile/building/text.xml
+++ b/ebuild-writing/functions/src_compile/building/text.xml
@@ -19,8 +19,8 @@ cleanly, it should be patched.
 </p>
 
 <p>
-If patching <e>really</e> isn't an option, <c>emake -j1</c> should be
-used. However, when doing this, please remember that you are seriously
+If patching <e>really</e> isn't an option, <c>emake -j1 --shuffle=none</c> should
+be used. However, when doing this, please remember that you are seriously
 hurting build times for many non-x86 users in particular. Forcing
 <c>-j1</c> can increase build times from a few minutes to an hour on
 some MIPS and SPARC systems.

--- a/ebuild-writing/functions/src_install/text.xml
+++ b/ebuild-writing/functions/src_install/text.xml
@@ -98,7 +98,7 @@ install to a non-root location. If possible, this should be used:
 
 <note>
 <c>emake</c> should be used to parallelise here. Some installs are
-not designed to be parallelised, use <c>emake -j1</c> or <c>make</c>
+not designed to be parallelised, use <c>emake -j1 --shuffle=none</c>
 if you hit an error.
 </note>
 


### PR DESCRIPTION
Thanks to trofi, GNU make 4.4 gained the --shuffle option to detect unsound Makefiles [1]. Gentoo's tinderboxes use --shuffle to find and report such issues. However, they also would report broken Makefiles where the ebuild author knew that the Makefile is broken, and hence added -j1 to the make invocation [2]..

To stop Tinderboxes from creating noise by reporting known issues, this change devmanual to suggest pairing -j1 with --shuffle=none for the *compile* case. Devmanual also suggest to consider -j1 for resource intensive testsuites, but this does not require --shuffle.

1: https://trofi.github.io/posts/249-an-update-on-make-shuffle.html
2: https://bugs.gentoo.org/947303#c10
Signed-off-by: Florian Schmaus <flow@gentoo.org>