### PR TITLE
general-concepts/dependencies: Mention BDEPEND

### DIFF
--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -743,8 +743,10 @@ tarball.
 
 <p>
 Packages often have optional dependencies that are needed only when running
-tests. These should be specified in DEPEND behind a USE flag. Often, the
-'test' USE flag is used for this purpose.
+tests. These should be specified in <c>BDEPEND</c> or <c>DEPEND</c> behind a
+USE flag
+(see also <uri link="::general-concepts/dependencies/#Build dependencies"/>).
+Often, the <c>test</c> USE flag is used for this purpose.
 </p>
 
 <p>


### PR DESCRIPTION
It can be confusing that only DEPEND is mentioned here, as some dependencies belong in BDEPEND behind a test USE flag instead.