### PR TITLE
ebuild-maintenance/removal: fix ebuild-name command list diff

### DIFF
--- a/ebuild-maintenance/removal/text.xml
+++ b/ebuild-maintenance/removal/text.xml
@@ -59,7 +59,7 @@ When removing packages follow these steps:
 </ol>
 
 <p>
-Here is a list of commands that will delete <c>dev-util/pmk</c>
+Here is a list of commands that will delete <c>dev-qt/qtphonon</c>
 from the tree:
 </p>
 


### PR DESCRIPTION
The list of commands talks about dev-util/pmk while actually dev-qt/qtphonon would get removed by the commands listed.

Fixes: 74b1623b6414 ("ebuild-maintenance: remove the Gentoo-Bug tag in the package removal subsection")

Related-to: https://bugs.gentoo.org/640788