### PR TITLE
devbook-guide: Clarify syntax of intra-document references

### DIFF
--- a/appendices/devbook-guide/text.xml
+++ b/appendices/devbook-guide/text.xml
@@ -552,6 +552,12 @@ I could have written the two examples above in more compact form:
 <uri link="::quickstart/#First ebuild"/>, respectively.
 </p>
 
+<important>
+The component after the octothorpe must be the <e>literal</e> section title.
+Don't copy the fragment identifier from HTML output! So, in the above example,
+it is not <c>#first-ebuild</c> but <c>#First ebuild</c>.
+</important>
+
 </body>
 </subsection>
 </section>


### PR DESCRIPTION
There's sometimes confusion about syntax of intra-document refs (most recently in #366). Add a clarification to the devbook guide.