### PR TITLE
 keywording: Explain how Stabilization groups works, mention pkgdev bugs, remove mention of ia64

### DIFF
--- a/keywording/text.xml
+++ b/keywording/text.xml
@@ -502,6 +502,11 @@ There are several tools available that can help with this:
     Use <c>pkgcheck</c>'s <c>StableRequest</c> check, e.g.
       <c>grep -ri "larry@" */*/metadata.xml -l | cut -d'/' -f1-2 | xargs pkgcheck scan -k StableRequest</c>
   </li>
+  <li>
+    Use <c>pkgdev bugs</c> for finding and filing stabilization bugs, e.g.
+    <c>pkgdev bugs --edit-graph --filter-stablereqs
+    --auto-cc-arches larry@gentoo.org --find-by-maintainer larry@gentoo.org</c>
+  </li>
 </ul>
 
 </body>


### PR DESCRIPTION
- Finally found the time to explain how stabilization groups works [1], how to use them. I think this is useful info for devmanual, especially since they are already used a lot in ::gentoo.

- Also dropped the mentions of ia64, found other arch to mention in each place (didn't want to just drop since it breaks the wrapping and I was too lazy to handle it)

- Also added sample invocation of pkgdev bugs to file bugs for stabilization candidates by maintainer email.

[1] https://public-inbox.gentoo.org/gentoo-dev/49ec2455-9055-c9f7-9619-723f0d2a7ebf@gentoo.org/